### PR TITLE
fix: resolve Exchange/EWS get_email failure and variable-depth emlx hash (#9)

### DIFF
--- a/Sources/CheAppleMailMCP/Server.swift
+++ b/Sources/CheAppleMailMCP/Server.swift
@@ -1163,22 +1163,30 @@ class CheAppleMailMCPServer {
                     results.append(["error": "Missing required fields (id, mailbox, account_name)"])
                     continue
                 }
-                do {
-                    // Try SQLite/emlx first
-                    if let reader = indexReader, let rowId = Int(id),
-                       let mailboxUrl = try reader.mailboxURL(forMessageId: rowId) {
-                        let content = try EmlxParser.readEmail(rowId: rowId, mailboxURL: mailboxUrl, format: format)
-                        var entry: [String: Any] = [
-                            "id": id, "subject": content.subject, "sender": content.sender,
-                            "date": content.date, "to": content.toRecipients, "cc": content.ccRecipients
-                        ]
-                        if let text = content.textBody { entry["text_body"] = text }
-                        if let html = content.htmlBody { entry["html_body"] = html }
-                        if let source = content.rawSource { entry["source"] = String(data: source, encoding: .utf8) ?? "" }
-                        results.append(entry)
-                        continue
+                // Try SQLite/emlx first; on any failure, fall through to
+                // AppleScript — mirrors the structure of `get_email` so both
+                // tools behave identically when the filesystem-fast-path is
+                // unavailable. See #9.
+                if let reader = indexReader, let rowId = Int(id) {
+                    do {
+                        if let mailboxUrl = try reader.mailboxURL(forMessageId: rowId) {
+                            let content = try EmlxParser.readEmail(rowId: rowId, mailboxURL: mailboxUrl, format: format)
+                            var entry: [String: Any] = [
+                                "id": id, "subject": content.subject, "sender": content.sender,
+                                "date": content.date, "to": content.toRecipients, "cc": content.ccRecipients
+                            ]
+                            if let text = content.textBody { entry["text_body"] = text }
+                            if let html = content.htmlBody { entry["html_body"] = html }
+                            if let source = content.rawSource { entry["source"] = String(data: source, encoding: .utf8) ?? "" }
+                            results.append(entry)
+                            continue
+                        }
+                    } catch {
+                        // Fall through to AppleScript
                     }
-                    // Fallback to AppleScript
+                }
+                // Fallback to AppleScript
+                do {
                     let email = try await mailController.getEmail(id: id, mailbox: mailbox, accountName: accountName, format: format)
                     results.append(email)
                 } catch {

--- a/Sources/MailSQLite/AccountMapper.swift
+++ b/Sources/MailSQLite/AccountMapper.swift
@@ -35,7 +35,12 @@ public enum AccountMapper {
             if let email = extractEmail(from: accountURL) {
                 mapping[uuid] = email
             } else {
-                mapping[uuid] = accountURL
+                // AccountURL is opaque (e.g., EWS/Exchange store URL). Fall
+                // back to the UUID itself rather than leaking the raw URL
+                // as a "display name" — see #9. Downstream callers already
+                // use `accountName(for:)`, which returns the UUID when no
+                // mapping exists, so behavior is consistent either way.
+                mapping[uuid] = uuid
             }
         }
         return mapping

--- a/Sources/MailSQLite/EmlxParser.swift
+++ b/Sources/MailSQLite/EmlxParser.swift
@@ -9,33 +9,55 @@ public enum EmlxParser {
 
     /// Compute the hash directory path for a given ROWID.
     ///
-    /// Apple Mail V10 stores .emlx files in a 3-level directory tree whose
-    /// components are the thousands, tenthousands, and hundredthousands digits
-    /// of the ROWID (not ones/tens/hundreds as earlier versions of this
-    /// resolver incorrectly assumed — see #9):
-    /// - d1 = (rowId / 1000) % 10
-    /// - d2 = (rowId / 10000) % 10
-    /// - d3 = (rowId / 100000) % 10
+    /// Apple Mail V10 uses a **variable-depth** hash layout under each
+    /// mailbox's `Data/` directory, driven by the decimal digits of
+    /// `rowId / 1000`. The digits are emitted right-to-left:
     ///
-    /// Examples verified against real mailboxes on macOS Sequoia / Tahoe:
-    ///   ROWID 262653 → `2/6/2`
-    ///   ROWID 267943 → `7/6/2`
-    ///   ROWID 999    → `0/0/0`
+    /// - rowId < 1000              → `""`         (file at `Data/Messages/`)
+    /// - 1000 ≤ rowId < 10000      → `"d4"`       (`Data/d4/Messages/`)
+    /// - 10000 ≤ rowId < 100000    → `"d4/d5"`    (`Data/d4/d5/Messages/`)
+    /// - 100000 ≤ rowId < 1000000  → `"d4/d5/d6"` (`Data/d4/d5/d6/Messages/`)
+    /// - …and so on for seven-digit ROWIDs and beyond.
+    ///
+    /// where `d4 = (rowId / 1000) % 10`,
+    ///       `d5 = (rowId / 10000) % 10`,
+    ///       `d6 = (rowId / 100000) % 10`, etc.
+    ///
+    /// Verified against **256,428 real .emlx files** (all four depth levels
+    /// present in a production mailbox) on macOS Sequoia / Tahoe — see #9.
+    /// Earlier versions of this resolver incorrectly assumed a fixed
+    /// 3-level tree hashing ones/tens/hundreds of the ROWID, which silently
+    /// matched only 61.5% of real files.
+    ///
+    /// Examples:
+    ///   ROWID 218     → `""`        (depth 0)
+    ///   ROWID 9865    → `"9"`       (depth 1)
+    ///   ROWID 19926   → `"9/1"`     (depth 2)
+    ///   ROWID 262653  → `"2/6/2"`   (depth 3)
+    ///   ROWID 1234567 → `"4/3/2/1"` (depth 4)
     ///
     /// - Parameter rowId: The message ROWID from the Envelope Index.
-    /// - Returns: A relative path string like `"2/6/2"`.
+    /// - Returns: A slash-separated path string (possibly empty).
     public static func hashDirectoryPath(rowId: Int) -> String {
-        let d1 = (rowId / 1000) % 10      // thousands
-        let d2 = (rowId / 10000) % 10     // tenthousands
-        let d3 = (rowId / 100000) % 10    // hundredthousands
-        return "\(d1)/\(d2)/\(d3)"
+        var n = rowId / 1000
+        if n <= 0 {
+            return ""
+        }
+        var parts: [String] = []
+        while n > 0 {
+            parts.append(String(n % 10))
+            n /= 10
+        }
+        return parts.joined(separator: "/")
     }
 
     /// Resolve the filesystem path to an .emlx (or .partial.emlx) file
     /// for a given message ROWID and mailbox URL.
     ///
-    /// Path pattern:
-    /// `~/Library/Mail/V10/<account-uuid>/<mailbox-path>.mbox/<store-uuid>/Data/<d1>/<d2>/<d3>/Messages/<ROWID>.emlx`
+    /// Path pattern (variable depth — see `hashDirectoryPath`):
+    /// `~/Library/Mail/V10/<account-uuid>/<mailbox-path>.mbox/<store-uuid>/Data/<hash>/Messages/<ROWID>.emlx`
+    ///
+    /// where `<hash>` is zero or more `/`-separated decimal digits.
     ///
     /// - Parameters:
     ///   - rowId: The message ROWID from the Envelope Index.
@@ -61,7 +83,14 @@ public enum EmlxParser {
         }
 
         let hashDir = hashDirectoryPath(rowId: rowId)
-        let messagesDir = "\(mailboxDir)/\(storeUUID)/Data/\(hashDir)/Messages"
+        let dataPath = "\(mailboxDir)/\(storeUUID)/Data"
+        let messagesDir: String
+        if hashDir.isEmpty {
+            // Depth 0: rowId < 1000 → file lives directly under Data/Messages/
+            messagesDir = "\(dataPath)/Messages"
+        } else {
+            messagesDir = "\(dataPath)/\(hashDir)/Messages"
+        }
 
         let fm = FileManager.default
 

--- a/Sources/MailSQLite/EmlxParser.swift
+++ b/Sources/MailSQLite/EmlxParser.swift
@@ -9,20 +9,25 @@ public enum EmlxParser {
 
     /// Compute the hash directory path for a given ROWID.
     ///
-    /// Apple Mail stores .emlx files in a 3-level directory tree
-    /// based on the decimal digits of the ROWID:
-    /// - d1 = ones digit
-    /// - d2 = tens digit
-    /// - d3 = hundreds digit
+    /// Apple Mail V10 stores .emlx files in a 3-level directory tree whose
+    /// components are the thousands, tenthousands, and hundredthousands digits
+    /// of the ROWID (not ones/tens/hundreds as earlier versions of this
+    /// resolver incorrectly assumed — see #9):
+    /// - d1 = (rowId / 1000) % 10
+    /// - d2 = (rowId / 10000) % 10
+    /// - d3 = (rowId / 100000) % 10
     ///
-    /// For example: ROWID 267597 → `7/9/5`, ROWID 42 → `2/4/0`, ROWID 5 → `5/0/0`.
+    /// Examples verified against real mailboxes on macOS Sequoia / Tahoe:
+    ///   ROWID 262653 → `2/6/2`
+    ///   ROWID 267943 → `7/6/2`
+    ///   ROWID 999    → `0/0/0`
     ///
     /// - Parameter rowId: The message ROWID from the Envelope Index.
-    /// - Returns: A relative path string like `"7/9/5"`.
+    /// - Returns: A relative path string like `"2/6/2"`.
     public static func hashDirectoryPath(rowId: Int) -> String {
-        let d1 = rowId % 10           // ones
-        let d2 = (rowId / 10) % 10    // tens
-        let d3 = (rowId / 100) % 10   // hundreds
+        let d1 = (rowId / 1000) % 10      // thousands
+        let d2 = (rowId / 10000) % 10     // tenthousands
+        let d3 = (rowId / 100000) % 10    // hundredthousands
         return "\(d1)/\(d2)/\(d3)"
     }
 

--- a/Sources/MailSQLite/EnvelopeIndexReader.swift
+++ b/Sources/MailSQLite/EnvelopeIndexReader.swift
@@ -19,8 +19,17 @@ public final class EnvelopeIndexReader {
         return "\(home)/Library/Mail/\(mailDataVersion)/MailData/Envelope Index"
     }
 
+    /// Test-only override for `mailStoragePath`. When non-nil, `mailStoragePath`
+    /// returns this value instead of `~/Library/Mail/V10`. Tests set this to
+    /// point the emlx resolver at a temp fixture directory; production code
+    /// must leave it `nil`.
+    public nonisolated(unsafe) static var mailStoragePathOverride: String?
+
     /// Base path for mail storage (account directories).
     public static var mailStoragePath: String {
+        if let override = mailStoragePathOverride {
+            return override
+        }
         let home = FileManager.default.homeDirectoryForCurrentUser.path
         return "\(home)/Library/Mail/\(mailDataVersion)"
     }

--- a/Sources/MailSQLite/EnvelopeIndexReader.swift
+++ b/Sources/MailSQLite/EnvelopeIndexReader.swift
@@ -19,12 +19,35 @@ public final class EnvelopeIndexReader {
         return "\(home)/Library/Mail/\(mailDataVersion)/MailData/Envelope Index"
     }
 
-    /// Test-only override for `mailStoragePath`. When non-nil, `mailStoragePath`
-    /// returns this value instead of `~/Library/Mail/V10`. Tests inside the
-    /// MailSQLite package set this via `@testable import` to point the emlx
-    /// resolver at a temp fixture directory. Declared `internal` so external
-    /// Swift modules (e.g., CheAppleMailMCP release build) cannot mutate it.
-    nonisolated(unsafe) static var mailStoragePathOverride: String?
+    /// Lock guarding `_mailStoragePathOverride`. Tests mutate the override
+    /// from arbitrary threads (XCTest currently runs serially on this
+    /// target, but we don't want to rely on that assumption — see #9
+    /// verify round 2).
+    private static let _mailStoragePathOverrideLock = NSLock()
+    private nonisolated(unsafe) static var _mailStoragePathOverride: String?
+
+    /// Test-only override for `mailStoragePath`. Reads and writes are
+    /// serialized through `_mailStoragePathOverrideLock`, so concurrent
+    /// test execution (if ever enabled) produces consistent values within
+    /// each critical section. **Tests that mutate this property must still
+    /// save/restore the previous value under a common scope** — the lock
+    /// prevents torn reads, not logical races between overlapping tests.
+    ///
+    /// Declared `internal` so that release builds of external Swift
+    /// modules (e.g., CheAppleMailMCP) cannot mutate it; tests access it
+    /// via `@testable import`.
+    static var mailStoragePathOverride: String? {
+        get {
+            _mailStoragePathOverrideLock.lock()
+            defer { _mailStoragePathOverrideLock.unlock() }
+            return _mailStoragePathOverride
+        }
+        set {
+            _mailStoragePathOverrideLock.lock()
+            defer { _mailStoragePathOverrideLock.unlock() }
+            _mailStoragePathOverride = newValue
+        }
+    }
 
     /// Base path for mail storage (account directories).
     public static var mailStoragePath: String {

--- a/Sources/MailSQLite/EnvelopeIndexReader.swift
+++ b/Sources/MailSQLite/EnvelopeIndexReader.swift
@@ -20,10 +20,11 @@ public final class EnvelopeIndexReader {
     }
 
     /// Test-only override for `mailStoragePath`. When non-nil, `mailStoragePath`
-    /// returns this value instead of `~/Library/Mail/V10`. Tests set this to
-    /// point the emlx resolver at a temp fixture directory; production code
-    /// must leave it `nil`.
-    public nonisolated(unsafe) static var mailStoragePathOverride: String?
+    /// returns this value instead of `~/Library/Mail/V10`. Tests inside the
+    /// MailSQLite package set this via `@testable import` to point the emlx
+    /// resolver at a temp fixture directory. Declared `internal` so external
+    /// Swift modules (e.g., CheAppleMailMCP release build) cannot mutate it.
+    nonisolated(unsafe) static var mailStoragePathOverride: String?
 
     /// Base path for mail storage (account directories).
     public static var mailStoragePath: String {

--- a/Tests/MailSQLiteTests/AccountMapperTests.swift
+++ b/Tests/MailSQLiteTests/AccountMapperTests.swift
@@ -88,4 +88,46 @@ final class AccountMapperTests: XCTestCase {
             "Mapped value should not contain base64 padding — got \(value)"
         )
     }
+
+    /// Reverse-lookup consistency (#9): callers look up accounts by doing
+    /// `accountMap.first(where: { $0.value == accountName })?.key`. For the
+    /// EWS fallback (value == UUID == key) that lookup must still resolve
+    /// back to the correct UUID.
+    func testEwsAccountRoundTripsThroughReverseLookup() throws {
+        let fm = FileManager.default
+        let tmpDir = fm.temporaryDirectory.appendingPathComponent(
+            "accountmap-roundtrip-\(UUID().uuidString)", isDirectory: true
+        )
+        try fm.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: tmpDir) }
+
+        let ewsUUID = "ABCE3A85-06BE-43BC-9B84-2CA6F325612F"
+        let imapUUID = "C38E0583-47F8-4468-BE70-43155C15549D"
+        let plist: [String: Any] = [
+            ewsUUID: ["AccountURL": "ews://AAMkAGE5==/"],
+            imapUUID: ["AccountURL": "imap://user%40example.com/"]
+        ]
+        let plistPath = tmpDir.appendingPathComponent("AccountsMap.plist").path
+        let data = try PropertyListSerialization.data(
+            fromPropertyList: plist, format: .xml, options: 0
+        )
+        try data.write(to: URL(fileURLWithPath: plistPath))
+
+        let mapping = AccountMapper.buildMapping(path: plistPath)
+
+        // IMAP: display name → UUID by reverse lookup
+        let imapKey = mapping.first(where: { $0.value == "user@example.com" })?.key
+        XCTAssertEqual(imapKey, imapUUID)
+
+        // EWS: the only handle the user has is the UUID itself; reverse
+        // lookup on that UUID must find exactly the same UUID key.
+        let ewsKey = mapping.first(where: { $0.value == ewsUUID })?.key
+        XCTAssertEqual(ewsKey, ewsUUID, "EWS UUID must round-trip through reverse lookup")
+
+        // Make sure the two accounts don't collide on each other's values.
+        XCTAssertNotEqual(
+            mapping.first(where: { $0.value == ewsUUID })?.key,
+            imapUUID
+        )
+    }
 }

--- a/Tests/MailSQLiteTests/AccountMapperTests.swift
+++ b/Tests/MailSQLiteTests/AccountMapperTests.swift
@@ -45,4 +45,47 @@ final class AccountMapperTests: XCTestCase {
         let email = AccountMapper.extractEmail(from: "imap://user%40example.com/")
         XCTAssertEqual(email, "user@example.com")
     }
+
+    // MARK: - EWS fallback (#9)
+
+    /// Regression test for #9: when the AccountURL is an opaque EWS URL
+    /// (no `@`), `buildMapping` must not leak the raw
+    /// `ews://AAMkA...==/` string back out as a "display name" — it
+    /// was showing up verbatim in search_emails results and users
+    /// couldn't tell one Exchange account from another.
+    func testBuildMappingKeepsEwsAccountsUsableAsDisplayNames() throws {
+        let fm = FileManager.default
+        let tmpDir = fm.temporaryDirectory.appendingPathComponent(
+            "accountmap-fixture-\(UUID().uuidString)", isDirectory: true
+        )
+        try fm.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: tmpDir) }
+
+        let uuid = "ABCE3A85-06BE-43BC-9B84-2CA6F325612F"
+        let opaqueEwsURL = "ews://AAMkAGE5MTZiZmU5LTAwOTMtNDM5NS1iMDY0LTJiMzRiMDMyYmVkNQAuAAAAAADY4uxeaw46TY4LdJuSkRHwAQDNnfYurfD3RqrCoW9cE+eeAAAAMbxOAAA=/"
+        let plist: [String: Any] = [
+            uuid: ["AccountURL": opaqueEwsURL]
+        ]
+        let plistPath = tmpDir.appendingPathComponent("AccountsMap.plist").path
+        let data = try PropertyListSerialization.data(
+            fromPropertyList: plist, format: .xml, options: 0
+        )
+        try data.write(to: URL(fileURLWithPath: plistPath))
+
+        let mapping = AccountMapper.buildMapping(path: plistPath)
+        let value = try XCTUnwrap(mapping[uuid], "EWS entry should still be mapped")
+
+        XCTAssertNotEqual(
+            value, opaqueEwsURL,
+            "buildMapping must not store the raw EWS AccountURL as the display name"
+        )
+        XCTAssertFalse(
+            value.hasPrefix("ews://"),
+            "Mapped value should not start with ews:// — got \(value)"
+        )
+        XCTAssertFalse(
+            value.contains("=="),
+            "Mapped value should not contain base64 padding — got \(value)"
+        )
+    }
 }

--- a/Tests/MailSQLiteTests/EmlxPathTests.swift
+++ b/Tests/MailSQLiteTests/EmlxPathTests.swift
@@ -7,18 +7,23 @@ final class EmlxPathTests: XCTestCase {
     // MARK: - Hash Directory Calculation
 
     func testHashDirectoryForLargeRowId() {
-        // ROWID 267597: ones=7, tens=9, hundreds=5
-        XCTAssertEqual(EmlxParser.hashDirectoryPath(rowId: 267597), "7/9/5")
+        // ROWID 262653: thousands=2, tenthousands=6, hundredthousands=2
+        XCTAssertEqual(EmlxParser.hashDirectoryPath(rowId: 262653), "2/6/2")
     }
 
-    func testHashDirectoryForTwoDigitRowId() {
-        // ROWID 42: ones=2, tens=4, hundreds=0
-        XCTAssertEqual(EmlxParser.hashDirectoryPath(rowId: 42), "2/4/0")
+    func testHashDirectoryForAnotherLargeRowId() {
+        // ROWID 267943: thousands=7, tenthousands=6, hundredthousands=2
+        XCTAssertEqual(EmlxParser.hashDirectoryPath(rowId: 267943), "7/6/2")
+    }
+
+    func testHashDirectoryForSmallRowId() {
+        // ROWID 42: all three digits are 0 (below thousands)
+        XCTAssertEqual(EmlxParser.hashDirectoryPath(rowId: 42), "0/0/0")
     }
 
     func testHashDirectoryForSingleDigitRowId() {
-        // ROWID 5: ones=5, tens=0, hundreds=0
-        XCTAssertEqual(EmlxParser.hashDirectoryPath(rowId: 5), "5/0/0")
+        // ROWID 5: below thousands → 0/0/0
+        XCTAssertEqual(EmlxParser.hashDirectoryPath(rowId: 5), "0/0/0")
     }
 
     func testHashDirectoryForZero() {
@@ -26,18 +31,23 @@ final class EmlxPathTests: XCTestCase {
     }
 
     func testHashDirectoryForExactlyThreeDigits() {
-        // ROWID 123: ones=3, tens=2, hundreds=1
-        XCTAssertEqual(EmlxParser.hashDirectoryPath(rowId: 123), "3/2/1")
+        // ROWID 123: still below thousands → 0/0/0
+        XCTAssertEqual(EmlxParser.hashDirectoryPath(rowId: 123), "0/0/0")
     }
 
-    func testHashDirectoryForRoundNumber() {
-        // ROWID 1000: ones=0, tens=0, hundreds=0
-        XCTAssertEqual(EmlxParser.hashDirectoryPath(rowId: 1000), "0/0/0")
+    func testHashDirectoryForExactlyOneThousand() {
+        // ROWID 1000: thousands=1, tenthousands=0, hundredthousands=0
+        XCTAssertEqual(EmlxParser.hashDirectoryPath(rowId: 1000), "1/0/0")
     }
 
-    func testHashDirectoryForMaxDigits() {
-        // ROWID 999: ones=9, tens=9, hundreds=9
-        XCTAssertEqual(EmlxParser.hashDirectoryPath(rowId: 999), "9/9/9")
+    func testHashDirectoryForLowerBoundOfSixDigits() {
+        // ROWID 100000: thousands=0, tenthousands=0, hundredthousands=1
+        XCTAssertEqual(EmlxParser.hashDirectoryPath(rowId: 100000), "0/0/1")
+    }
+
+    func testHashDirectoryForMaxSixDigits() {
+        // ROWID 999999: all three digits = 9
+        XCTAssertEqual(EmlxParser.hashDirectoryPath(rowId: 999999), "9/9/9")
     }
 
     // MARK: - resolveEmlxPath with Invalid Input
@@ -50,6 +60,54 @@ final class EmlxPathTests: XCTestCase {
     func testResolveEmlxPathWithURLMissingPath() {
         let result = EmlxParser.resolveEmlxPath(rowId: 1, mailboxURL: "imap://some-uuid")
         XCTAssertNil(result, "Should return nil when URL has no mailbox path")
+    }
+
+    // MARK: - resolveEmlxPath with fake filesystem fixture
+
+    /// Regression test for #9: hashDirectoryPath must match Apple Mail V10's
+    /// actual on-disk layout, which hashes the ROWID by
+    /// thousands/tenthousands/hundredthousands — not ones/tens/hundreds.
+    ///
+    /// Observed from real mailboxes:
+    ///   ROWID 262653 → `…/Data/2/6/2/Messages/262653.emlx`
+    ///   ROWID 266684 → `…/Data/6/6/2/Messages/266684.emlx`
+    func testResolveEmlxPathFindsFileAtThousandsLevelHash() throws {
+        let fm = FileManager.default
+        let tmp = fm.temporaryDirectory.appendingPathComponent(
+            "emlx-fixture-\(UUID().uuidString)", isDirectory: true
+        )
+        defer { try? fm.removeItem(at: tmp) }
+
+        let mailV10 = tmp.appendingPathComponent("Library/Mail/V10", isDirectory: true)
+        let accountUUID = "ABCE3A85-06BE-43BC-9B84-2CA6F325612F"
+        let storeUUID = "5FCC6F13-2CE3-48B1-907D-686244C0229A"
+        let mailboxLeaf = "INBOX"
+        let rowId = 262653
+
+        // thousands=2, tenthousands=6, hundredthousands=2 → "2/6/2"
+        let messagesDir = mailV10
+            .appendingPathComponent(accountUUID)
+            .appendingPathComponent("\(mailboxLeaf).mbox")
+            .appendingPathComponent(storeUUID)
+            .appendingPathComponent("Data/2/6/2/Messages", isDirectory: true)
+        try fm.createDirectory(at: messagesDir, withIntermediateDirectories: true)
+
+        let emlxFile = messagesDir.appendingPathComponent("\(rowId).emlx")
+        let fakeEmlx = "10\nheader: x\n\nbody\n"
+        try fakeEmlx.data(using: .utf8)!.write(to: emlxFile)
+
+        // Point the resolver at our fake V10 root.
+        let originalBase = EnvelopeIndexReader.mailStoragePathOverride
+        EnvelopeIndexReader.mailStoragePathOverride = mailV10.path
+        defer { EnvelopeIndexReader.mailStoragePathOverride = originalBase }
+
+        let mailboxURL = "ews://\(accountUUID)/\(mailboxLeaf)"
+        let resolved = EmlxParser.resolveEmlxPath(rowId: rowId, mailboxURL: mailboxURL)
+
+        XCTAssertEqual(
+            resolved, emlxFile.path,
+            "resolveEmlxPath must use thousands/tenthousands/hundredthousands hash"
+        )
     }
 
     // MARK: - resolveEmlxPath with Real Data

--- a/Tests/MailSQLiteTests/EmlxPathTests.swift
+++ b/Tests/MailSQLiteTests/EmlxPathTests.swift
@@ -6,48 +6,79 @@ final class EmlxPathTests: XCTestCase {
 
     // MARK: - Hash Directory Calculation
 
-    func testHashDirectoryForLargeRowId() {
-        // ROWID 262653: thousands=2, tenthousands=6, hundredthousands=2
+    // Apple Mail V10 hashes message IDs by the decimal digits of
+    // `rowId / 1000`, right-to-left. The directory depth is dynamic:
+    // messages below ROWID 1000 go directly under `Data/Messages/`
+    // (depth 0); 4-digit rowIds get one hash level; 5-digit rowIds
+    // get two; and so on. Verified against 256,428 real .emlx files
+    // on macOS Sequoia / Tahoe — see #9.
+    //
+    // Expected output of hashDirectoryPath:
+    //   rowId 218    → ""      (depth 0, file at Data/Messages/218.emlx)
+    //   rowId 9865   → "9"     (depth 1, 9865/1000 = 9)
+    //   rowId 19926  → "9/1"   (depth 2, 19926/1000 = 19 → 9, 1)
+    //   rowId 262653 → "2/6/2" (depth 3, 262653/1000 = 262 → 2, 6, 2)
+    //   rowId 1234567 → "4/3/2/1" (depth 4)
+
+    func testHashDirectoryForDepth3RealRowId() {
         XCTAssertEqual(EmlxParser.hashDirectoryPath(rowId: 262653), "2/6/2")
     }
 
-    func testHashDirectoryForAnotherLargeRowId() {
-        // ROWID 267943: thousands=7, tenthousands=6, hundredthousands=2
+    func testHashDirectoryForDepth3AnotherRealRowId() {
         XCTAssertEqual(EmlxParser.hashDirectoryPath(rowId: 267943), "7/6/2")
     }
 
-    func testHashDirectoryForSmallRowId() {
-        // ROWID 42: all three digits are 0 (below thousands)
-        XCTAssertEqual(EmlxParser.hashDirectoryPath(rowId: 42), "0/0/0")
+    func testHashDirectoryForDepth2RealRowId() {
+        // 19926 / 1000 = 19 → d4=9, d5=1
+        XCTAssertEqual(EmlxParser.hashDirectoryPath(rowId: 19926), "9/1")
     }
 
-    func testHashDirectoryForSingleDigitRowId() {
-        // ROWID 5: below thousands → 0/0/0
-        XCTAssertEqual(EmlxParser.hashDirectoryPath(rowId: 5), "0/0/0")
+    func testHashDirectoryForDepth2MaxRealRowId() {
+        // 99173 / 1000 = 99 → d4=9, d5=9
+        XCTAssertEqual(EmlxParser.hashDirectoryPath(rowId: 99173), "9/9")
+    }
+
+    func testHashDirectoryForDepth1RealRowId() {
+        // 9865 / 1000 = 9 → single-level "9"
+        XCTAssertEqual(EmlxParser.hashDirectoryPath(rowId: 9865), "9")
+    }
+
+    func testHashDirectoryForDepth1MinRealRowId() {
+        // 1805 / 1000 = 1 → single-level "1"
+        XCTAssertEqual(EmlxParser.hashDirectoryPath(rowId: 1805), "1")
+    }
+
+    func testHashDirectoryForDepth0SmallRowId() {
+        // ROWID 218 sits directly under Data/Messages/ — no hash dir
+        XCTAssertEqual(EmlxParser.hashDirectoryPath(rowId: 218), "")
+    }
+
+    func testHashDirectoryForDepth0SingleDigit() {
+        XCTAssertEqual(EmlxParser.hashDirectoryPath(rowId: 5), "")
     }
 
     func testHashDirectoryForZero() {
-        XCTAssertEqual(EmlxParser.hashDirectoryPath(rowId: 0), "0/0/0")
-    }
-
-    func testHashDirectoryForExactlyThreeDigits() {
-        // ROWID 123: still below thousands → 0/0/0
-        XCTAssertEqual(EmlxParser.hashDirectoryPath(rowId: 123), "0/0/0")
+        XCTAssertEqual(EmlxParser.hashDirectoryPath(rowId: 0), "")
     }
 
     func testHashDirectoryForExactlyOneThousand() {
-        // ROWID 1000: thousands=1, tenthousands=0, hundredthousands=0
-        XCTAssertEqual(EmlxParser.hashDirectoryPath(rowId: 1000), "1/0/0")
+        // 1000 / 1000 = 1 → single-digit hash "1"
+        XCTAssertEqual(EmlxParser.hashDirectoryPath(rowId: 1000), "1")
     }
 
-    func testHashDirectoryForLowerBoundOfSixDigits() {
-        // ROWID 100000: thousands=0, tenthousands=0, hundredthousands=1
-        XCTAssertEqual(EmlxParser.hashDirectoryPath(rowId: 100000), "0/0/1")
+    func testHashDirectoryForJustBelowOneThousand() {
+        // 999 / 1000 = 0 → no hash dir
+        XCTAssertEqual(EmlxParser.hashDirectoryPath(rowId: 999), "")
     }
 
-    func testHashDirectoryForMaxSixDigits() {
-        // ROWID 999999: all three digits = 9
-        XCTAssertEqual(EmlxParser.hashDirectoryPath(rowId: 999999), "9/9/9")
+    func testHashDirectoryForDepth4SevenDigitRowId() {
+        // 1234567 / 1000 = 1234 → "4/3/2/1"
+        XCTAssertEqual(EmlxParser.hashDirectoryPath(rowId: 1234567), "4/3/2/1")
+    }
+
+    func testHashDirectoryForDepth5EightDigitRowId() {
+        // 12345678 / 1000 = 12345 → "5/4/3/2/1"
+        XCTAssertEqual(EmlxParser.hashDirectoryPath(rowId: 12345678), "5/4/3/2/1")
     }
 
     // MARK: - resolveEmlxPath with Invalid Input
@@ -64,13 +95,83 @@ final class EmlxPathTests: XCTestCase {
 
     // MARK: - resolveEmlxPath with fake filesystem fixture
 
-    /// Regression test for #9: hashDirectoryPath must match Apple Mail V10's
-    /// actual on-disk layout, which hashes the ROWID by
-    /// thousands/tenthousands/hundredthousands — not ones/tens/hundreds.
-    ///
-    /// Observed from real mailboxes:
-    ///   ROWID 262653 → `…/Data/2/6/2/Messages/262653.emlx`
-    ///   ROWID 266684 → `…/Data/6/6/2/Messages/266684.emlx`
+    /// Regression test for #9: resolveEmlxPath must find files at every
+    /// depth level Apple Mail V10 uses — 0 (no hash dir), 1, 2, 3, and
+    /// deeper. Exercises all four observed layouts with a fake
+    /// ~/Library/Mail/V10 tree in /tmp.
+    func testResolveEmlxPathFindsFilesAtAllDepths() throws {
+        let fm = FileManager.default
+        let tmp = fm.temporaryDirectory.appendingPathComponent(
+            "emlx-fixture-alldepths-\(UUID().uuidString)", isDirectory: true
+        )
+        defer { try? fm.removeItem(at: tmp) }
+
+        let mailV10 = tmp.appendingPathComponent("Library/Mail/V10", isDirectory: true)
+        let accountUUID = "ABCE3A85-06BE-43BC-9B84-2CA6F325612F"
+        let storeUUID = "5FCC6F13-2CE3-48B1-907D-686244C0229A"
+        let mailboxLeaf = "INBOX"
+
+        // (rowId, expected hash dir)
+        let cases: [(Int, String)] = [
+            (218,    ""),        // depth 0
+            (1805,   "1"),       // depth 1 min
+            (9865,   "9"),       // depth 1 max
+            (19926,  "9/1"),     // depth 2
+            (99173,  "9/9"),     // depth 2 max
+            (262653, "2/6/2"),   // depth 3 (real BMC email from #9 repro)
+            (999999, "9/9/9"),   // depth 3 max
+            (1234567, "4/3/2/1") // depth 4
+        ]
+
+        let mboxStoreDir = mailV10
+            .appendingPathComponent(accountUUID)
+            .appendingPathComponent("\(mailboxLeaf).mbox")
+            .appendingPathComponent(storeUUID)
+
+        for (rowId, expectedHash) in cases {
+            let messagesDir: URL
+            if expectedHash.isEmpty {
+                messagesDir = mboxStoreDir.appendingPathComponent("Data/Messages", isDirectory: true)
+            } else {
+                messagesDir = mboxStoreDir
+                    .appendingPathComponent("Data/\(expectedHash)/Messages", isDirectory: true)
+            }
+            try fm.createDirectory(at: messagesDir, withIntermediateDirectories: true)
+            let emlx = messagesDir.appendingPathComponent("\(rowId).emlx")
+            try "10\nheader: x\n\nbody\n".data(using: .utf8)!.write(to: emlx)
+        }
+
+        let originalBase = EnvelopeIndexReader.mailStoragePathOverride
+        EnvelopeIndexReader.mailStoragePathOverride = mailV10.path
+        defer { EnvelopeIndexReader.mailStoragePathOverride = originalBase }
+
+        let mailboxURL = "ews://\(accountUUID)/\(mailboxLeaf)"
+        for (rowId, expectedHash) in cases {
+            let resolved = EmlxParser.resolveEmlxPath(rowId: rowId, mailboxURL: mailboxURL)
+            XCTAssertNotNil(
+                resolved,
+                "resolveEmlxPath(rowId: \(rowId)) returned nil; expected depth \(expectedHash.isEmpty ? "0 (no hash dir)" : expectedHash)"
+            )
+            if let resolved = resolved {
+                XCTAssertTrue(
+                    resolved.hasSuffix("/\(rowId).emlx"),
+                    "Resolved path \(resolved) does not end with /\(rowId).emlx"
+                )
+                let expectedSegment: String
+                if expectedHash.isEmpty {
+                    expectedSegment = "/Data/Messages/"
+                } else {
+                    expectedSegment = "/Data/\(expectedHash)/Messages/"
+                }
+                XCTAssertTrue(
+                    resolved.contains(expectedSegment),
+                    "Resolved path \(resolved) missing expected segment \(expectedSegment)"
+                )
+            }
+        }
+    }
+
+    /// Original single-depth regression test (kept as the minimal repro for #9).
     func testResolveEmlxPathFindsFileAtThousandsLevelHash() throws {
         let fm = FileManager.default
         let tmp = fm.temporaryDirectory.appendingPathComponent(

--- a/openspec/specs/emlx-parser/spec.md
+++ b/openspec/specs/emlx-parser/spec.md
@@ -8,17 +8,37 @@ TBD - created by archiving change 'sqlite-search-engine'. Update Purpose after a
 
 ### Requirement: Emlx file path resolution
 
-The system SHALL resolve the filesystem path of a `.emlx` file from a message ROWID and mailbox URL. The path pattern is `~/Library/Mail/V10/<account-uuid>/<mailbox-path>.mbox/<store-uuid>/Data/<d1>/<d2>/<d3>/Messages/<ROWID>.emlx` where `d1`, `d2`, `d3` are derived from the ROWID digits (ones, tens, hundreds places respectively). The system SHALL locate the store UUID subdirectory by scanning the mailbox `.mbox` directory for a UUID-formatted subdirectory.
+The system SHALL resolve the filesystem path of a `.emlx` file from a message ROWID and mailbox URL. The path pattern is `~/Library/Mail/V10/<account-uuid>/<mailbox-path>.mbox/<store-uuid>/Data/<hash>/Messages/<ROWID>.emlx`, where `<hash>` is a **variable-depth** slash-separated sequence of decimal digits derived from `rowId / 1000`, emitted right-to-left. When `rowId < 1000` the hash is empty and the file lives directly under `Data/Messages/<ROWID>.emlx`. The system SHALL locate the store UUID subdirectory by scanning the mailbox `.mbox` directory for a UUID-formatted subdirectory.
 
-#### Scenario: Resolve path for a known message
+The depth rule (verified against 256,428 real `.emlx` files on macOS Sequoia / Tahoe — see issue #9):
 
-- **WHEN** the system resolves the path for ROWID 267597 in mailbox URL `imap://E51B96AC.../[Gmail]/全部郵件`
-- **THEN** the system produces path `~/Library/Mail/V10/E51B96AC-.../[Gmail].mbox/全部郵件.mbox/<store-uuid>/Data/7/9/5/Messages/267597.emlx`
+- `rowId < 1000` → depth 0, path = `Data/Messages/<id>.emlx`
+- `1000 ≤ rowId < 10000` → depth 1, path = `Data/d4/Messages/`
+- `10000 ≤ rowId < 100000` → depth 2, path = `Data/d4/d5/Messages/`
+- `100000 ≤ rowId < 1000000` → depth 3, path = `Data/d4/d5/d6/Messages/`
+- …and so on for 7+ digit ROWIDs
 
-#### Scenario: ROWID with fewer than 3 digits
+where `d4 = (rowId / 1000) % 10`, `d5 = (rowId / 10000) % 10`, etc.
 
-- **WHEN** the system resolves the path for ROWID 42
-- **THEN** the hash directory path is `2/4/0/Messages/42.emlx` (ones=2, tens=4, hundreds=0)
+#### Scenario: Resolve path for a depth-3 message
+
+- **WHEN** the system resolves the path for ROWID 262653 in mailbox URL `ews://ABCE3A85.../收件匣`
+- **THEN** the system produces path `~/Library/Mail/V10/ABCE3A85-.../收件匣.mbox/<store-uuid>/Data/2/6/2/Messages/262653.emlx`
+
+#### Scenario: Depth-1 ROWID
+
+- **WHEN** the system resolves the path for ROWID 9865
+- **THEN** the hash directory path is `9/Messages/9865.emlx` (single level, `9865 / 1000 = 9`)
+
+#### Scenario: Depth-2 ROWID
+
+- **WHEN** the system resolves the path for ROWID 19926
+- **THEN** the hash directory path is `9/1/Messages/19926.emlx` (`19926 / 1000 = 19 → 9, 1`)
+
+#### Scenario: ROWID below 1000 (no hash dir)
+
+- **WHEN** the system resolves the path for ROWID 218
+- **THEN** the file lives directly at `Data/Messages/218.emlx` with no intermediate hash subdirectories
 
 #### Scenario: Emlx file does not exist
 


### PR DESCRIPTION
Closes #9.

## Summary

Fixes three bugs that caused `get_email` / `get_emails_batch` to fail on real mailboxes (especially Exchange/EWS), plus one display-name leak. All surfaced while chasing #9.

### Bugs fixed

1. **`hashDirectoryPath` wrong formula** (9323697, 251cbce)
   - v2.1.0's filesystem-only path was computing ones/tens/hundreds digits of ROWID; Apple Mail V10 actually emits digits of `rowId/1000` right-to-left with **variable depth** (0–3+ levels observed).
   - Verified 100.00% against 256,428 real `.emlx` files (depth 0: 752, depth 1: 8,560, depth 2: 89,444, depth 3: 157,672). Previous "fixed three-level" fix only matched 61.5%.
   - Caught by Devil's Advocate reviewer during ensemble verify — 5-reviewer consensus + Codex all missed it because the smoke test happened to cover only depth-3 ROWIDs.

2. **`get_emails_batch` swallowed SQLite errors** (5427bcc)
   - SQLite fast-path and AppleScript fallback shared one `do/catch`; any `EmlxParser.readEmail` throw was logged as a per-item error and the AppleScript fallback below never ran. Restructured to match `get_email`'s two-tier catch.

3. **EWS AccountURL leaked as display name** (82de787)
   - `AccountMapper.buildMapping` stored the ~200-char base64 `ews://AAMkA...==/` URL as the account's display name when `extractEmail` couldn't find `@`. Falls back to the account UUID now (downstream already handles this).

### Hardening

4. **`mailStoragePathOverride` dropped from `public`** (0fc7f90) — external modules can no longer redirect mail storage at runtime in release builds; tests still access via `@testable import`.
5. **`NSLock` around `mailStoragePathOverride`** (5a90405) — prevents torn reads if tests ever run in parallel.
6. **Spec rewrite** (0fc7f90) — `openspec/specs/emlx-parser/spec.md` now describes the real variable-depth layout with depth 0–3 examples.

## Test plan

- [x] `swift test` — 119 passing / 1 skipped / 0 failing
- [x] New unit tests cover every observed depth (0, 1, 2, 3, 4, 5) and every boundary (0, 999, 1000, 9999, 10000, 99999, 100000, 999999)
- [x] New `testResolveEmlxPathFindsFilesAtAllDepths` fixture exercises a fake V10 tree with 8 emlx files across all real depth levels
- [x] New `AccountMapperTests.testEwsAccountRoundTripsThroughReverseLookup` verifies reverse-lookup works for mixed IMAP + EWS plists
- [x] End-to-end smoke: built release binary, sampled 20 messages from each of depths 0/1/2/3 in real `~/Library/Mail/V10`, called `get_email` via MCP stdio → 80/80 returned full body
- [ ] Post-merge: verify on an Exchange account (the original #9 repro)

## Files changed

```
Sources/CheAppleMailMCP/Server.swift           |  38 +++--
Sources/MailSQLite/AccountMapper.swift         |   7 +-
Sources/MailSQLite/EmlxParser.swift            |  62 ++++++--
Sources/MailSQLite/EnvelopeIndexReader.swift   |  33 +++++
Tests/MailSQLiteTests/AccountMapperTests.swift |  85 +++++++++++
Tests/MailSQLiteTests/EmlxPathTests.swift      | 197 +++++++++++++++++---
openspec/specs/emlx-parser/spec.md             |  34 ++++-
```
