### PR TITLE
fix: reply_email plain mode embeds quoted original via Swift-side compose (#43)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`reply_email` plain mode now embeds quoted original message in the draft body** ([#43](https://github.com/PsychQuant/che-apple-mail-mcp/issues/43)). Pre-fix every plain-format `reply_email` call since `b8a4a89` (initial release) silently produced bare-body replies because the AppleScript `set content to "<body>" & return & return & content` pattern read the outgoing message's `content` property as empty — Mail.app does not populate the quoted body until the GUI compose pipeline materializes it (especially when `without opening window` is used for `save_as_draft=true`). Fix: pre-fetch the original content unconditionally and Swift-side compose RFC 3676 `> `-prefixed quoted body via a new `composeReplyPlainText` helper. The HTML branch was already correct (it always pre-fetched and built `<blockquote>`). **Wire-output behavioral change**: every plain-format reply body now reads `<user reply>\n\n> <each line of original>` instead of just `<user reply>`. Round-1 verify hardening: CRLF/CR normalization, trailing-newline trim, empty-line `>` stuffing per RFC 3676 §4.5, and graceful degrade when pre-fetch fails (sandbox / deleted message → "no quote" rather than abort).
+
+### Changed
+- **`reply_email` MCP tool description and `format` parameter description updated** to document the new RFC 3676 quoted-body behavior for plain mode. The previous wording ("preserves existing concatenation semantics") was misleading because the underlying behavior was broken; the new wording reflects what the tool actually does.
+- **`openspec/specs/message-composition/spec.md` Scenario "Reply in plain mode"** rewritten from `"Thanks\n\n<original plain content>"` to RFC 3676 quoted form, with a `> ` prefix on every original line and `>` (no trailing space) on empty lines.
+
 ## [2.4.1] - 2026-05-02
 
 ### Fixed

--- a/Sources/CheAppleMailMCP/AppleScript/ComposeScriptBuilder.swift
+++ b/Sources/CheAppleMailMCP/AppleScript/ComposeScriptBuilder.swift
@@ -110,6 +110,21 @@ func composeReplyHTML(userBody: String, userFormat: BodyFormat, originalHTML: St
     return "\(userPart)\n<hr>\n<blockquote>\n\(quoted)\n</blockquote>"
 }
 
+// Issue #43: AppleScript `& content` against a freshly-created outgoing message
+// returns empty before the GUI compose pipeline materializes the quoted body.
+// We pre-fetch the original plain text and Swift-side compose RFC 3676 quoted
+// reply body so the result is deterministic regardless of window state.
+func composeReplyPlainText(userBody: String, originalPlain: String) -> String {
+    if originalPlain.isEmpty {
+        return userBody
+    }
+    let quoted = originalPlain
+        .split(separator: "\n", omittingEmptySubsequences: false)
+        .map { "> \($0)" }
+        .joined(separator: "\n")
+    return "\(userBody)\n\n\(quoted)"
+}
+
 func buildReplyEmailScript(
     messageRef: String,
     userBody: String,
@@ -142,12 +157,13 @@ func buildReplyEmailScript(
     }()
 
     if userFormat == .plain {
+        let composedPlain = composeReplyPlainText(userBody: userBody, originalPlain: originalPlain)
         return """
         tell application "Mail"
             set originalMsg to \(messageRef)
             set replyMsg to \(replyType) originalMsg \(windowClause)
             tell replyMsg
-                set content to "\(appleScriptEscape(userBody))" & return & return & content\(extraTellLines)
+                set content to "\(appleScriptEscape(composedPlain))"\(extraTellLines)
             end tell
             \(dispatchVerb) replyMsg
             return "\(returnMessage)"

--- a/Sources/CheAppleMailMCP/AppleScript/ComposeScriptBuilder.swift
+++ b/Sources/CheAppleMailMCP/AppleScript/ComposeScriptBuilder.swift
@@ -114,13 +114,30 @@ func composeReplyHTML(userBody: String, userFormat: BodyFormat, originalHTML: St
 // returns empty before the GUI compose pipeline materializes the quoted body.
 // We pre-fetch the original plain text and Swift-side compose RFC 3676 quoted
 // reply body so the result is deterministic regardless of window state.
+//
+// Round-1 hardening (#43 verify findings — Logic #1/2/3/5, Codex P1/P3):
+// - Normalize CRLF/CR → LF before splitting (Mail.app IMAP/Exchange messages
+//   sometimes return CRLF line endings).
+// - Strip trailing newlines (Mail.app commonly appends a trailing newline,
+//   which would emit a stray `> ` line at the end).
+// - For empty quoted lines, emit `>` (no trailing space) per RFC 3676 §4.5;
+//   only non-empty lines get the `> ` stuffing space.
+// - After normalization, if there is no quotable content (e.g. originalPlain
+//   was just whitespace/newlines), return userBody alone.
 func composeReplyPlainText(userBody: String, originalPlain: String) -> String {
-    if originalPlain.isEmpty {
+    let normalized = originalPlain
+        .replacingOccurrences(of: "\r\n", with: "\n")
+        .replacingOccurrences(of: "\r", with: "\n")
+    var trimmed = Substring(normalized)
+    while let last = trimmed.last, last == "\n" {
+        trimmed = trimmed.dropLast()
+    }
+    if trimmed.isEmpty {
         return userBody
     }
-    let quoted = originalPlain
+    let quoted = trimmed
         .split(separator: "\n", omittingEmptySubsequences: false)
-        .map { "> \($0)" }
+        .map { $0.isEmpty ? ">" : "> \($0)" }
         .joined(separator: "\n")
     return "\(userBody)\n\n\(quoted)"
 }

--- a/Sources/CheAppleMailMCP/AppleScript/MailController.swift
+++ b/Sources/CheAppleMailMCP/AppleScript/MailController.swift
@@ -676,10 +676,22 @@ actor MailController {
         // `& content` against a freshly-created outgoing message reads as empty
         // before Mail.app's GUI populates it, which silently dropped the quoted
         // original from every plain reply since b8a4a89 (initial release).
-        let fetched = try runScript(buildFetchOriginalContentScript(messageRef: ref))
-        let parsed = parseFetchedOriginalContent(fetched)
-        let originalHTML = parsed.html
-        let originalPlain = parsed.plain
+        //
+        // Round-1 hardening (#43 verify Logic #4 / DA-3): pre-fetch failure
+        // (sandbox -1743, message deleted, ICloud server-side body) must not
+        // hard-fail the whole reply. Fall back to "no quote" so the user's
+        // body is still preserved and the reply can still be sent/saved.
+        let originalHTML: String?
+        let originalPlain: String
+        do {
+            let fetched = try runScript(buildFetchOriginalContentScript(messageRef: ref))
+            let parsed = parseFetchedOriginalContent(fetched)
+            originalHTML = parsed.html
+            originalPlain = parsed.plain
+        } catch {
+            originalHTML = nil
+            originalPlain = ""
+        }
 
         let script = try buildReplyEmailScript(
             messageRef: ref,

--- a/Sources/CheAppleMailMCP/AppleScript/MailController.swift
+++ b/Sources/CheAppleMailMCP/AppleScript/MailController.swift
@@ -671,14 +671,15 @@ actor MailController {
         if let attachments = attachments { try validateFilePaths(attachments) }
         let ref = msgRef(id, mailbox: mailbox, account: accountName)
 
-        var originalHTML: String? = nil
-        var originalPlain = ""
-        if format != .plain {
-            let fetched = try runScript(buildFetchOriginalContentScript(messageRef: ref))
-            let parsed = parseFetchedOriginalContent(fetched)
-            originalHTML = parsed.html
-            originalPlain = parsed.plain
-        }
+        // Issue #43: pre-fetch unconditionally — plain mode also needs originalPlain
+        // so composeReplyPlainText can build RFC 3676 quoted body. AppleScript's
+        // `& content` against a freshly-created outgoing message reads as empty
+        // before Mail.app's GUI populates it, which silently dropped the quoted
+        // original from every plain reply since b8a4a89 (initial release).
+        let fetched = try runScript(buildFetchOriginalContentScript(messageRef: ref))
+        let parsed = parseFetchedOriginalContent(fetched)
+        let originalHTML = parsed.html
+        let originalPlain = parsed.plain
 
         let script = try buildReplyEmailScript(
             messageRef: ref,

--- a/Sources/CheAppleMailMCP/Server.swift
+++ b/Sources/CheAppleMailMCP/Server.swift
@@ -233,7 +233,7 @@ class CheAppleMailMCPServer {
             ),
             Tool(
                 name: "reply_email",
-                description: "Reply to an email. Body formatting is controlled by the 'format' parameter (default: 'plain'; use 'markdown' or 'html' for rich text). Non-plain modes wrap the original message in a blockquote. Optionally add extra CC, attach files, and save as draft instead of sending.",
+                description: "Reply to an email. Body formatting is controlled by the 'format' parameter (default: 'plain'; use 'markdown' or 'html' for rich text). 'plain' embeds the original message as RFC 3676 `> `-prefixed quoted lines; 'markdown'/'html' wrap the original in a `<blockquote>`. Optionally add extra CC, attach files, and save as draft instead of sending.",
                 inputSchema: .object([
                     "type": .string("object"),
                     "properties": .object([
@@ -245,7 +245,7 @@ class CheAppleMailMCPServer {
                         "cc_additional": .object(["type": .string("array"), "items": .object(["type": .string("string")]), "description": .string("Extra CC recipients to add on top of those derived from 'reply_all'. Email addresses (RFC 5322 addr-spec).")]),
                         "attachments": .object(["type": .string("array"), "items": .object(["type": .string("string")]), "description": .string("Absolute file paths to attach to the reply.")]),
                         "save_as_draft": .object(["type": .string("boolean"), "description": .string("If true, save the reply as a draft instead of sending it (default: false). Use when you want a human to review before send.")]),
-                        "format": .object(["type": .string("string"), "enum": .array([.string("plain"), .string("markdown"), .string("html")]), "description": .string("Body format. 'plain' (default) preserves existing concatenation semantics; 'markdown'/'html' produce rich text and wrap the original in a blockquote.")])
+                        "format": .object(["type": .string("string"), "enum": .array([.string("plain"), .string("markdown"), .string("html")]), "description": .string("Body format. 'plain' (default) prepends the user body to the original message quoted with RFC 3676 `> ` line prefix; 'markdown'/'html' produce rich text and wrap the original in a `<blockquote>`.")])
                     ]),
                     "required": .array([.string("id"), .string("mailbox"), .string("account_name"), .string("body")])
                 ])

--- a/Tests/CheAppleMailMCPTests/MailControllerComposeTests.swift
+++ b/Tests/CheAppleMailMCPTests/MailControllerComposeTests.swift
@@ -174,10 +174,47 @@ final class MailControllerComposeTests: XCTestCase {
             userBody: "Reply",
             originalPlain: "Para 1\n\nPara 2"
         )
-        // RFC 3676: quoted empty lines stay quoted (preserves paragraph breaks visually)
+        // RFC 3676 §4.5: quoted empty lines emit `>` only (no trailing space stuffing
+        // when there is no content). Round-1 hardening (#43 verify Logic #3).
         XCTAssertTrue(result.contains("> Para 1"))
         XCTAssertTrue(result.contains("> Para 2"))
-        XCTAssertTrue(result.contains("> \n"), "blank lines between quoted paragraphs must remain prefixed")
+        XCTAssertTrue(result.contains(">\n"), "blank quoted lines must remain prefixed (with bare `>`)")
+        XCTAssertFalse(result.contains("> \n"), "blank quoted lines MUST NOT have trailing-space stuffing (RFC 3676 §4.5)")
+    }
+
+    func testComposeReplyPlainText_originalWithCRLF_normalizesLineEndings() {
+        // Round-1 hardening (#43 verify Logic #5 / Codex P1): Mail.app IMAP /
+        // Exchange messages return CRLF line endings. The helper must normalize
+        // them so the AppleScript escape doesn't smuggle stray `\r` through.
+        let result = composeReplyPlainText(
+            userBody: "Reply",
+            originalPlain: "Line 1\r\nLine 2\r\nLine 3"
+        )
+        XCTAssertTrue(result.contains("> Line 1"))
+        XCTAssertTrue(result.contains("> Line 2"))
+        XCTAssertTrue(result.contains("> Line 3"))
+        XCTAssertFalse(result.contains("\r"), "CRLF / CR characters MUST be normalized to LF before quoting")
+    }
+
+    func testComposeReplyPlainText_originalWithSingleNewline_returnsUserBodyOnly() {
+        // Round-1 hardening (#43 verify Logic #1 / Codex P3): Mail.app sometimes
+        // returns "\n" or "\n\n" as the plain content for HTML-only messages.
+        // Treat as no-quotable-content rather than emitting stray `>` lines.
+        XCTAssertEqual(composeReplyPlainText(userBody: "Hi", originalPlain: "\n"), "Hi")
+        XCTAssertEqual(composeReplyPlainText(userBody: "Hi", originalPlain: "\n\n\n"), "Hi")
+        XCTAssertEqual(composeReplyPlainText(userBody: "Hi", originalPlain: "\r\n"), "Hi")
+    }
+
+    func testComposeReplyPlainText_originalWithTrailingNewline_dropsStrayQuoteLine() {
+        // Round-1 hardening (#43 verify Logic #2): Mail.app commonly appends a
+        // trailing newline. Without trim, the helper would emit `> ` (with
+        // trailing space) as a stray last quote line.
+        let result = composeReplyPlainText(
+            userBody: "Reply",
+            originalPlain: "Body line\n"
+        )
+        XCTAssertTrue(result.hasSuffix("> Body line"), "result MUST end at the last real quoted line, no stray `> ` afterwards")
+        XCTAssertFalse(result.contains("> \n"), "trailing newline MUST NOT produce a `> ` (with trailing space) stray line")
     }
 
     // MARK: - buildReplyEmailScript

--- a/Tests/CheAppleMailMCPTests/MailControllerComposeTests.swift
+++ b/Tests/CheAppleMailMCPTests/MailControllerComposeTests.swift
@@ -147,9 +147,66 @@ final class MailControllerComposeTests: XCTestCase {
         XCTAssertTrue(result.contains("<br>"), "plain-only original newlines must become <br>")
     }
 
+    // MARK: - composeReplyPlainText (issue #43 fix)
+
+    func testComposeReplyPlainText_prependsUserBody_quotesOriginalLines() {
+        let result = composeReplyPlainText(
+            userBody: "Thanks, noted.",
+            originalPlain: "Can you review?\nThe deadline is Friday."
+        )
+        XCTAssertTrue(result.hasPrefix("Thanks, noted."), "user body must come first")
+        XCTAssertTrue(result.contains("> Can you review?"), "each original line must be `> `-prefixed (RFC 3676)")
+        XCTAssertTrue(result.contains("> The deadline is Friday."), "every original line must be quoted")
+        XCTAssertTrue(result.contains("Thanks, noted.\n\n> "), "user body and quote block separated by blank line")
+    }
+
+    func testComposeReplyPlainText_emptyOriginal_returnsUserBodyOnly() {
+        let result = composeReplyPlainText(
+            userBody: "Just a heads-up.",
+            originalPlain: ""
+        )
+        XCTAssertEqual(result, "Just a heads-up.", "empty originalPlain must NOT emit a stray quote block")
+        XCTAssertFalse(result.contains("> "), "no `> ` prefix when no original to quote")
+    }
+
+    func testComposeReplyPlainText_originalWithEmptyLines_keepsQuotedEmptyLines() {
+        let result = composeReplyPlainText(
+            userBody: "Reply",
+            originalPlain: "Para 1\n\nPara 2"
+        )
+        // RFC 3676: quoted empty lines stay quoted (preserves paragraph breaks visually)
+        XCTAssertTrue(result.contains("> Para 1"))
+        XCTAssertTrue(result.contains("> Para 2"))
+        XCTAssertTrue(result.contains("> \n"), "blank lines between quoted paragraphs must remain prefixed")
+    }
+
     // MARK: - buildReplyEmailScript
 
-    func testBuildReplyEmailScript_plainMode_keepsAmpersandConcatenation() throws {
+    func testBuildReplyEmailScript_plainMode_includesQuotedOriginal() throws {
+        // Issue #43 fix: plain branch now Swift-side composes the quoted body
+        // (RFC 3676 `> ` prefix) instead of relying on the broken
+        // `& return & return & content` AppleScript pattern, which silently
+        // produced bare-body replies because Mail.app does not populate the
+        // outgoing message's `content` until the GUI compose window materializes.
+        let script = try buildReplyEmailScript(
+            messageRef: "msgRef",
+            userBody: "Reply body",
+            userFormat: .plain,
+            replyAll: false,
+            originalHTML: nil,
+            originalPlain: "Original line 1\nOriginal line 2"
+        )
+        XCTAssertTrue(script.contains("set content to"), "plain mode still uses `set content to`")
+        XCTAssertTrue(script.contains("> Original line 1"), "quoted original line must appear in the script literal")
+        XCTAssertTrue(script.contains("> Original line 2"), "every original line must be quoted")
+        XCTAssertFalse(script.contains("& return & return & content"), "broken AppleScript `& content` pattern MUST be removed (#43)")
+        XCTAssertFalse(script.contains("html content"), "plain mode MUST NOT touch html content")
+        XCTAssertFalse(script.contains("<blockquote>"), "plain mode MUST NOT wrap in blockquote (HTML tag)")
+    }
+
+    func testBuildReplyEmailScript_plainMode_emptyOriginal_omitsQuoteBlock() throws {
+        // Edge case for #43: when no original content was pre-fetched (e.g.
+        // pre-fetch failed or original is empty), do NOT emit a stray `> ` line.
         let script = try buildReplyEmailScript(
             messageRef: "msgRef",
             userBody: "Reply body",
@@ -158,10 +215,10 @@ final class MailControllerComposeTests: XCTestCase {
             originalHTML: nil,
             originalPlain: ""
         )
-        XCTAssertTrue(script.contains("set content to"))
-        XCTAssertTrue(script.contains("& return & return & content"), "plain mode MUST keep existing concatenation semantics")
-        XCTAssertFalse(script.contains("html content"), "plain mode MUST NOT touch html content")
-        XCTAssertFalse(script.contains("<blockquote>"), "plain mode MUST NOT wrap in blockquote")
+        XCTAssertTrue(script.contains("set content to"), "plain mode still uses `set content to`")
+        XCTAssertTrue(script.contains("Reply body"), "user body must appear")
+        XCTAssertFalse(script.contains("> "), "empty originalPlain MUST NOT emit `> ` quote prefix")
+        XCTAssertFalse(script.contains("& return & return & content"), "broken AppleScript `& content` pattern MUST be removed (#43)")
     }
 
     func testBuildReplyEmailScript_markdownMode_setsHTMLContentWithBlockquote() throws {

--- a/openspec/specs/message-composition/spec.md
+++ b/openspec/specs/message-composition/spec.md
@@ -84,11 +84,16 @@ When `reply_email` or `forward_email` is invoked with `format` set to `"markdown
 - **THEN** the returned HTML SHALL contain `<blockquote>`
 - **AND** the blockquote content SHALL contain `Can you &lt;review&gt;?` (HTML-escaped)
 
-#### Scenario: Reply in plain mode keeps existing concatenation
+#### Scenario: Reply in plain mode embeds RFC 3676 quoted original
 
 - **WHEN** a caller invokes `reply_email` with `body: "Thanks"` and `format: "plain"` (or omits format)
-- **THEN** the reply SHALL use the AppleScript `content` property with value `"Thanks\n\n<original plain content>"`
+- **THEN** the reply SHALL use the AppleScript `content` property
+- **AND** the value SHALL be `"Thanks\n\n> <line 1 of original plain content>\n> <line 2>\n..."` — the user body, a blank line, then the original plain message with each line prefixed by `"> "` (greater-than + space) per RFC 3676 §4.5
+- **AND** empty lines in the original SHALL be quoted as `">"` (no trailing space) per RFC 3676 §4.5 stuffing rule
 - **AND** the reply SHALL NOT use the AppleScript `html content` property
+- **AND** if the pre-fetch of original content fails (e.g. message deleted, sandbox denial), the reply SHALL gracefully degrade to the user body alone (no quoted block) rather than aborting the entire reply
+
+> **Note (#43)**: Pre-v2.5.0 the plain branch used `set content to "<body>" & return & return & content`, which silently produced bare-body replies because Mail.app's outgoing-message `content` property is empty until the GUI compose pipeline materializes the quoted body. Replaced with Swift-side composition (`composeReplyPlainText`) that pre-fetches and quotes deterministically.
 
 ---
 ### Requirement: Signature preservation is out of scope


### PR DESCRIPTION
Refs #43

## Summary

Fix `reply_email` plain mode embedding the original message as RFC 3676 `> `-prefixed quoted body. Pre-fix every plain-format reply since `b8a4a89` (initial release) silently produced bare-body replies because the AppleScript `set content to "X" & return & return & content` pattern read the outgoing-message `content` property as empty (Mail.app does not populate the quoted body until the GUI compose pipeline materializes it, which `without opening window` skips entirely).

Strategy C from the diagnosis comment: parallel the existing html branch architecture — pre-fetch the original via `buildFetchOriginalContentScript`, Swift-side compose the quoted body via a new `composeReplyPlainText` helper, and `set content to "<composed>"` directly in AppleScript.

## Commits

- `49d79df` initial fix: helper + caller pre-fetch + plain branch refactor + 5 unit tests
- `49489d7` round-1 verify hardening: CRLF normalization, trailing newline trim, RFC 3676 §4.5 quote-line stuffing, graceful pre-fetch failure degrade, MCP tool description rewrite, openspec spec scenario rewrite, CHANGELOG entry

## Wire-output behavioral change

Every plain-format `reply_email` call from this PR forward produces a draft body of the shape:

```
<user reply>

> <line 1 of original>
> <line 2 of original>
> ...
```

Pre-fix behavior was `<user reply>` only (quoted original silently dropped). This is documented in CHANGELOG `[Unreleased]` and openspec `message-composition/spec.md` Scenario "Reply in plain mode".

## Verification

**6-AI cross-validation PASS** (Agent Team 5 reviewers + Codex gpt-5.5-xhigh).

- Round 1: 18 findings identified across 6 reviewers
- Round-1 auto-fix in `49489d7` resolved all 6 convergent in-scope findings (Logic #1/2/3/4/5, Regression #1/2/4, Codex P1/P2/P3, DA-3)
- 12 deferred findings filed as follow-up issues #44–#50
- Final state: **234 tests pass, 5 skipped (gated integration)**

Full verify report: <https://github.com/PsychQuant/che-apple-mail-mcp/issues/43#issuecomment-4364233101>

## Checklist

- [x] Diagnose ✓ <https://github.com/PsychQuant/che-apple-mail-mcp/issues/43#issuecomment-4364180011>
- [x] Implement (2 commits) ✓
- [x] Verify ✓ (6-AI cross-validation, round-1 auto-fix applied)
- [ ] **Pending: human review of this PR + `/idd-close #43` after merge**

## Related (follow-ups filed)

- #44 fix: forward_email plain branch has same `& content` bug
- #45 test: gated integration test for reply_email runtime draft body
- #46 smoke: verify reply_email RFC 3676 quote renders correctly across mail clients
- #47 smoke: verify reply_email saveAsDraft drafts collapse into Mail.app conversation view
- #48 docs: SECURITY.md note on RFC 3676 nested quote forgery
- #49 test: large originalPlain (long thread) AppleScript script size
- #50 security: id injection in msgRef AppleScript interpolation (P1, exposure doubled by #43)

Original Strategy C deferred items:
- Live AppleScript integration test (#45) — gated to #37
- forward_email plain branch parity (#44)

## Plan tier deliberation skipped

Issue #43 was assessed as **Plan complexity** (decision-heavy 3 strategies + 2+ files ordered dep + risk-sensitive wire-output change). Under unattended `/idd-all` orchestrator the Plan tier deliberation gate is skipped — the orchestrator routed straight to TDD loop. Reviewer should compensate by checking the verify findings + closing summary against original strategy intent before merge.

## Version bump

Recommend **minor (2.5.0)** rather than patch (2.4.2) given the user-visible wire-output change. `/mcp-tools:mcp-deploy` will prompt at release time.

---

🤖 Generated by `/issue-driven-dev:idd-all 43` (orchestrator). **Do NOT add `Closes #43`** — IDD discipline requires manual `/idd-close #43` after merge to enforce checklist gate + closing summary.
