### PR TITLE
fix: forward_email plain mode embeds quoted original (#44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`forward_email` plain mode now embeds quoted original message in the forwarded body** ([#44](https://github.com/PsychQuant/che-apple-mail-mcp/issues/44)). Same root cause as #43 (which fixed `reply_email`): AppleScript `& content` against a freshly-created outgoing message returns empty before Mail.app's GUI populates the quoted body, so every plain `forward_email` since `b8a4a89` (initial release) silently dropped the quoted original. Fix: lift the `if format != .plain` pre-fetch gate so `originalPlain` is always fetched (when a body is provided), wrapped in `try/catch` for graceful degrade; refactor plain branch in `buildForwardEmailScript` to use the existing `composeReplyPlainText` helper from #43 (reuses RFC 3676 `> ` prefix + CRLF normalization + trim + empty-line `>` stuffing). The HTML branch was already correct (uses `composeReplyHTML` + `<blockquote>`). **Wire-output behavioral change**: every plain-format `forward_email` body with a user-provided body now reads `<user body>\n\n> <quoted lines>` instead of just `<user body>`. Forward without body is unchanged (no quote block, no body mutation). The `forward_email` tool description updated accordingly.
+
 ## [2.5.0] - 2026-05-03
 
 ### Fixed

--- a/Sources/CheAppleMailMCP/AppleScript/ComposeScriptBuilder.swift
+++ b/Sources/CheAppleMailMCP/AppleScript/ComposeScriptBuilder.swift
@@ -227,8 +227,14 @@ func buildForwardEmailScript(
 
     if let body = userBody {
         if userFormat == .plain {
+            // Issue #44 (mirrors #43): use Swift-side composeReplyPlainText helper
+            // instead of broken `& content` AppleScript. The pre-fix pattern read
+            // outgoing message's `content` as empty before Mail.app's GUI populated
+            // the quoted body — every plain forward since b8a4a89 silently dropped
+            // the quoted original.
+            let composedPlain = composeReplyPlainText(userBody: body, originalPlain: originalPlain ?? "")
             script += "\n" + """
-                set content to "\(appleScriptEscape(body))" & return & return & content
+                set content to "\(appleScriptEscape(composedPlain))"
             """
         } else {
             let finalHTML = try composeReplyHTML(

--- a/Sources/CheAppleMailMCP/AppleScript/MailController.swift
+++ b/Sources/CheAppleMailMCP/AppleScript/MailController.swift
@@ -711,13 +711,28 @@ actor MailController {
     func forwardEmail(id: String, mailbox: String, accountName: String, to: [String], body: String? = nil, format: BodyFormat = .plain) throws -> String {
         let ref = msgRef(id, mailbox: mailbox, account: accountName)
 
-        var originalHTML: String? = nil
-        var originalPlain: String? = nil
-        if format != .plain, body != nil {
-            let fetched = try runScript(buildFetchOriginalContentScript(messageRef: ref))
-            let parsed = parseFetchedOriginalContent(fetched)
-            originalHTML = parsed.html
-            originalPlain = parsed.plain
+        // Issue #44 (mirrors #43): pre-fetch unconditionally when body is provided.
+        // Plain mode also needs originalPlain so composeReplyPlainText can build
+        // RFC 3676 quoted body — same root cause as #43 (AppleScript `& content`
+        // against fresh outgoing message returns empty before GUI populates it).
+        // Wrap in try/catch for graceful degrade (mirror #43 round-1 hardening):
+        // pre-fetch failure (sandbox -1743, deleted message) must not hard-fail
+        // the whole forward.
+        let originalHTML: String?
+        let originalPlain: String
+        if body != nil {
+            do {
+                let fetched = try runScript(buildFetchOriginalContentScript(messageRef: ref))
+                let parsed = parseFetchedOriginalContent(fetched)
+                originalHTML = parsed.html
+                originalPlain = parsed.plain
+            } catch {
+                originalHTML = nil
+                originalPlain = ""
+            }
+        } else {
+            originalHTML = nil
+            originalPlain = ""
         }
 
         let script = try buildForwardEmailScript(

--- a/Sources/CheAppleMailMCP/Server.swift
+++ b/Sources/CheAppleMailMCP/Server.swift
@@ -252,7 +252,7 @@ class CheAppleMailMCPServer {
             ),
             Tool(
                 name: "forward_email",
-                description: "Forward an email. Body formatting is controlled by the 'format' parameter (default: 'plain'; use 'markdown' or 'html' for rich text). Non-plain modes wrap the original message in a blockquote.",
+                description: "Forward an email. Body formatting is controlled by the 'format' parameter (default: 'plain'; use 'markdown' or 'html' for rich text). 'plain' embeds the original message as RFC 3676 `> `-prefixed quoted lines (when body is provided); 'markdown'/'html' wrap the original in a `<blockquote>`. Body is optional (omit for a bare forward without commentary).",
                 inputSchema: .object([
                     "type": .string("object"),
                     "properties": .object([

--- a/Tests/CheAppleMailMCPTests/MailControllerComposeTests.swift
+++ b/Tests/CheAppleMailMCPTests/MailControllerComposeTests.swift
@@ -417,19 +417,43 @@ final class MailControllerComposeTests: XCTestCase {
 
     // MARK: - buildForwardEmailScript
 
-    func testBuildForwardEmailScript_plainMode_withBody_keepsConcatenation() throws {
+    func testBuildForwardEmailScript_plainMode_withBody_includesQuotedOriginal() throws {
+        // Issue #44 (mirrors #43 fix): plain forward must embed the quoted
+        // original via Swift-side composeReplyPlainText helper, not the broken
+        // `& content` AppleScript pattern. See #43 closing summary for root cause.
         let script = try buildForwardEmailScript(
             messageRef: "msgRef",
             to: ["x@y.z"],
             userBody: "FYI",
             userFormat: .plain,
             originalHTML: nil,
-            originalPlain: nil
+            originalPlain: "Original line 1\nOriginal line 2"
         )
         XCTAssertTrue(script.contains("forward originalMsg"))
         XCTAssertTrue(script.contains("to recipient"))
         XCTAssertTrue(script.contains("set content to"))
-        XCTAssertTrue(script.contains("& return & return & content"))
+        XCTAssertTrue(script.contains("> Original line 1"), "quoted original must appear in script")
+        XCTAssertTrue(script.contains("> Original line 2"), "every original line must be quoted")
+        XCTAssertFalse(script.contains("& return & return & content"), "broken `& content` AppleScript pattern MUST be removed (#44)")
+        XCTAssertFalse(script.contains("html content"), "plain mode MUST NOT touch html content")
+    }
+
+    func testBuildForwardEmailScript_plainMode_emptyOriginal_omitsQuoteBlock() throws {
+        // Edge case mirror of #43: when pre-fetch returns empty originalPlain
+        // (e.g. message deleted, sandbox error, or no body to forward), do NOT
+        // emit a stray `> ` line. Helper composeReplyPlainText handles this via
+        // its isEmpty/whitespace-only guard.
+        let script = try buildForwardEmailScript(
+            messageRef: "msgRef",
+            to: ["x@y.z"],
+            userBody: "FYI",
+            userFormat: .plain,
+            originalHTML: nil,
+            originalPlain: ""
+        )
+        XCTAssertTrue(script.contains("set content to"))
+        XCTAssertTrue(script.contains("FYI"))
+        XCTAssertFalse(script.contains("> "), "empty originalPlain MUST NOT emit `> ` quote prefix")
         XCTAssertFalse(script.contains("html content"))
     }
 


### PR DESCRIPTION
Refs #44

## Summary

Fixes `forward_email` plain mode to embed the quoted original message in the forwarded body. Same bug class as #43 (which fixed `reply_email`): AppleScript `& content` against a freshly-created outgoing message returns empty before Mail.app's GUI populates the quoted body. Every plain `forward_email` since `b8a4a89` (initial release) silently dropped the quoted original.

Mirror of #43 architecture — reuses the existing `composeReplyPlainText` helper (added in #43, with full round-1 hardening: CRLF normalization, trim, empty-line `>` stuffing).

## Commits

- `e938176` fix: forward_email plain mode embeds quoted original (#44)

## Verification

**Tests**: 235 pass (was 234, added 1 edge-case test for empty originalPlain), 5 gated skip
**Build**: ✅ clean
**Wire-output change** disclosed in CHANGELOG `[Unreleased]` and forward_email tool description.

## Plan tier (skipped — Simple complexity)

Diagnosed as Simple in batch triage <https://github.com/PsychQuant/che-apple-mail-mcp/issues/44#issuecomment-4364760661> — pattern is mechanical mirroring of #43's approved Plan.

## Checklist

- [x] Diagnose ✓
- [x] Implement ✓
- [ ] Verify (deferred to batch verify post-marathon)
- [ ] **Pending: human review of this PR + /idd-close after merge**

## Related
- #43 (Closed) — parent fix; same architecture
- #45 (Open) — gated integration test framework should add forward_email coverage