### PR TITLE
docs: smoke matrix + threading verification templates (#46 #47)

### DIFF
--- a/docs/conversation-view-threading.md
+++ b/docs/conversation-view-threading.md
@@ -1,0 +1,85 @@
+# Mail.app Conversation-View Threading Verification
+
+> **Status**: template / data-collection harness. To be filled in by manual smoke test.
+> **Tracks**: [#47](https://github.com/PsychQuant/che-apple-mail-mcp/issues/47)
+> **Related**: [#43](https://github.com/PsychQuant/che-apple-mail-mcp/issues/43) — the user-reported symptom that motivated this verification
+
+## Why this verification exists
+
+#43's user-reported symptom was:
+
+> "save_as_draft=true 場景: user 看 Drafts 內 draft 像「不在 thread 裡」(其實 In-Reply-To/References 都對),因為 Mail.app conversation view 也參考 body 的 quoted content"
+> — issue #43 body, line 56
+
+The hypothesized root cause was "body lacks quoted original" (Mail.app conversation-view grouping reportedly considers body content in addition to RFC 5322 `In-Reply-To` / `References` headers). #43 fixed the hypothesized root cause (added RFC 3676 `> ` quote in plain mode), but **never verified the user-visible symptom resolved**.
+
+If RFC 3676 plain `> ` is NOT what Mail.app's conversation-view algorithm considers (only `<blockquote>` HTML?), then #43 fixed root cause A but symptom B persists.
+
+## Test setup
+
+Required: macOS Mail.app, an iCloud account (or any account showing conversation view), at least one real reply thread with intact `In-Reply-To` / `References` headers in INBOX.
+
+1. Identify a real reply thread:
+   ```
+   search_emails(query="<your test thread subject>", field="subject")
+   # Note the thread's "head" (oldest) message id
+   ```
+2. Confirm thread integrity in Mail.app: enable conversation view (View → Organize by Conversation), confirm the existing replies appear collapsed under one row with disclosure triangle.
+
+## Test protocol
+
+For each format (plain → markdown → html), repeat:
+
+```
+reply_email(
+    id="<head message id>",
+    mailbox="INBOX",
+    account_name="<account>",
+    body="Conversation-view threading test (#47, format=<format>)",
+    save_as_draft=true,
+    format="<format>"
+)
+```
+
+Then in Mail.app:
+- Switch to conversation view if not already
+- Locate the original thread
+- **Question**: does the new draft appear collapsed inside the original thread (disclosure triangle now shows N+1 messages)?
+
+## Results matrix
+
+Test conducted: **TBD**. CHE-APPLE-MAIL-MCP version: **v2.5.0+**.
+
+| Format | Quote in body? | Draft groups into thread? | Notes |
+|---|---|---|---|
+| `plain` | RFC 3676 `> ` (since #43) | TBD | Critical case for #47 |
+| `markdown` | `<blockquote>` HTML | TBD | If groups, `<blockquote>` is sufficient |
+| `html` | `<blockquote>` HTML | TBD | Same as markdown |
+
+## Conclusion drivers
+
+| Outcome | Action |
+|---|---|
+| All three formats group correctly | ✓ #43 fix complete; close #47 with positive result |
+| Only HTML groups, plain does not | Plain mode insufficient. Investigate: (a) switch default `format` from `plain` to `html` in `reply_email` (regression — bigger conversation), or (b) make plain mode emit MIME structure that conversation-view recognizes |
+| None group | Conversation-view doesn't use body. Different root cause for the original symptom — need separate investigation. Likely In-Reply-To / References issue |
+
+## Additional inspection
+
+If the answer is unclear, deep-dive on the MIME structure:
+
+```
+get_email(id="<draft id>", mailbox="Drafts", account_name="<account>", format="source")
+```
+
+Compare:
+- Manual `Cmd+R` reply MIME structure
+- `reply_email` (plain) MIME structure
+- `reply_email` (html) MIME structure
+
+Differences in `Content-Type` boundary, charset, or header presence may indicate what conversation-view keys on.
+
+## Historical context
+
+- **2026-05-03 (v2.5.0 / #43)**: shipped RFC 3676 `> ` quote in plain mode. User's symptom (draft not in thread) reported pre-#43; not re-verified post-#43.
+- **Pending**: results from this verification.

--- a/docs/quote-rendering-matrix.md
+++ b/docs/quote-rendering-matrix.md
@@ -1,0 +1,83 @@
+# RFC 3676 Quote Rendering Matrix
+
+> **Status**: template / data-collection harness. To be filled in by manual smoke test.
+> **Tracks**: [#46](https://github.com/PsychQuant/che-apple-mail-mcp/issues/46)
+> **Related**: [#43](https://github.com/PsychQuant/che-apple-mail-mcp/issues/43) (the wire-output change being verified)
+
+## Why this matrix exists
+
+`reply_email` plain mode (since v2.5.0 / #43) embeds the original message as RFC 3676 `> `-prefixed quoted text. RFC 3676 is the de facto standard, but mail clients differ in how they render the resulting body. This document tracks empirical observation across major recipient clients so we know whether the format-as-shipped requires further intervention (e.g., adding `Content-Type: text/plain; format=flowed; delsp=no` MIME header).
+
+## Test setup
+
+1. Sender: any account configured in `che-apple-mail-mcp`. Use a real account with sending capability (iCloud, Gmail, Exchange, etc.).
+2. Find a real reply thread in the sender INBOX (≥1 known message to reply to).
+3. Call:
+   ```
+   reply_email(
+       id="<message id from search_emails>",
+       mailbox="INBOX",
+       account_name="<account>",
+       body="Smoke test reply body — please confirm rendering of the quoted block below.",
+       format="plain"
+   )
+   ```
+   (No `save_as_draft` — we want to actually send to the recipient list.)
+4. Recipient list: include one address per client below.
+5. After receipt, screenshot how each client renders the message and fill in the table.
+
+## Render expectations
+
+What "correct" looks like:
+- The recipient's reply block is on top
+- A blank line separator
+- The quoted original is visually distinguished (sidebar, indent, gray color, collapsible "..." disclosure, etc.) — depending on client convention
+- `> ` prefix is NOT shown literally to the user
+
+What "broken" looks like:
+- `> ` prefix shown as literal text (no quote rendering)
+- Quote block hidden / dropped entirely
+- Quote block displayed but indistinguishable from main body
+
+## Matrix
+
+Test conducted: **TBD**. Test message: **TBD**. CHE-APPLE-MAIL-MCP version: **v2.5.0+**.
+
+| Recipient client | Expected | Actual | Notes |
+|---|---|---|---|
+| Apple Mail (macOS 14 / Sonoma) | quote block w/ vertical sidebar | TBD | Origin client |
+| Apple Mail (macOS 26+ / Tahoe) | quote block w/ vertical sidebar | TBD | Verify no regression on newer macOS |
+| Apple Mail (iOS 17+) | quote block w/ vertical sidebar | TBD | |
+| Gmail web (gmail.com) | collapsed `...` disclosure | TBD | Gmail's standard behavior for `> ` lines |
+| Gmail iOS app | similar to web | TBD | |
+| Outlook web (Office 365) | quoted block w/ left border | TBD | RFC 3676 compliant per docs |
+| Outlook desktop (Windows) | quoted block w/ left border | TBD | |
+| Outlook iOS app | similar to desktop | TBD | |
+| Thunderbird (latest, plain mode) | quote block w/ left border | TBD | **Risk**: needs `format=flowed` MIME header which we don't set |
+| Yahoo Mail web | TBD | TBD | Lower priority |
+| ProtonMail web | TBD | TBD | Lower priority |
+
+## Action triggers
+
+- **0-1 fringe clients render incorrectly** → ship as-is, document as known limitation in `SECURITY.md` / `README.md`.
+- **A major client (Gmail / Outlook / Apple) renders incorrectly** → escalate to add `Content-Type: text/plain; format=flowed; delsp=no` MIME header. Investigate AppleScript Mail.app surface for MIME header injection — likely requires `.emlx` raw write fallback.
+
+## Test message template
+
+Use this body when testing so observers can grade the rendering objectively:
+
+```
+Smoke test for che-apple-mail-mcp #46 / #43.
+
+If you can read this, please reply with how the quoted block below is rendered:
+- Visible as a quote block (sidebar / indent / gray text)? → ✓ correct
+- Visible as literal "> " prefixed text? → ✗ rendering broken
+- Hidden / dropped? → ✗ rendering broken
+
+Thanks!
+```
+
+## Historical context
+
+- **2026-05-03 (v2.5.0)**: #43 fix shipped RFC 3676 plain-text quoting. Pre-fix every plain reply since `b8a4a89` (initial release) silently dropped the quote.
+- **Pending**: this matrix's first row of data.


### PR DESCRIPTION
Refs #46, #47, #43

## Summary

Both smoke issues require manual mail-client testing — receiving on N clients (Gmail / Outlook / Thunderbird / etc.) to grade rendering, switching Mail.app to conversation view to check grouping. Cannot be automated from CI. This PR pre-creates the data-collection harness templates so the user has a clear protocol when running the manual smoke session.

## Commits

- `22ed3d7` docs: smoke matrix + threading verification templates (#46 #47)

## What's added

- `docs/quote-rendering-matrix.md` (#46): cross-client RFC 3676 render matrix (11 client/version rows), test protocol, action triggers
- `docs/conversation-view-threading.md` (#47): Mail.app conversation-view grouping verification protocol for plain/markdown/html formats

## What's NOT done (deferred to manual smoke)

- Actually sending the smoke messages to test recipients
- Filling in the matrix rows
- Drawing conclusions and triggering follow-up code changes (e.g., MIME header escalation if Thunderbird breaks)

## Why this approach

Both tracking issues will sit empty until someone actually runs the smoke. Pre-creating the templates:

1. Lowers activation energy — the protocol is written, observer just needs to receive + screenshot
2. Provides a concrete artifact even if smoke gets deferred indefinitely
3. The manual results, once filled in, become permanent documentation of cross-client behavior as of v2.5.0

## Plan tier (skipped — Simple)

Both diagnosed as Simple. Doc-only.

## Checklist

- [x] Diagnoses ✓ (#46, #47 in batch triage)
- [x] Implement (template stage) ✓
- [ ] Verify (the smoke testing IS the verification — deferred to user)
- [ ] **Pending: human review of this PR + run smoke + fill matrix + per-issue /idd-close**