### PR TITLE
fix(attachments): save_attachment honours .partial.emlx external folder (#66)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`save_attachment` no longer silently writes 0-byte files when only `.partial.emlx` exists** ([#66](https://github.com/PsychQuant/che-apple-mail-mcp/issues/66)). Pre-fix, `EmlxParser.saveAttachment` would happily `data.write(...)` an empty `Data()` and return `"Attachment saved to <path>"` (success) for any IMAP message Apple Mail had stripped to `.partial.emlx` — the MIME structure still declares the attachment via `Content-Disposition: filename`, but the base64 body is empty because the binary lives in the sibling `Attachments/<rowId>/<part_id>/<filename>` cache folder. Confirmed in the wild on 2026-05-04 against an outbound peer-review attachment retrieval (1.75 MB PDF in cache, MCP wrote 0 bytes, no error). Fix: when the matched MIME part has empty `decodedData`, walk `<hashDir>/Attachments/<rowId>/*/<filename>` and prefer the external bytes; if neither inline nor external file exists, throw `attachmentNotFound` so the AppleScript fallback (or the caller) surfaces the failure rather than producing a false success. The 100 MB size guard is applied to the externalised bytes too. Architecturally: the SQLite + .emlx fast path now handles `.partial.emlx` end-to-end; the AppleScript fallback at `Server.swift:1017` is no longer reached for this common pattern.
+
 ## [2.7.0] - 2026-05-03
 
 ### Fixed

--- a/Sources/MailSQLite/AttachmentExtractor.swift
+++ b/Sources/MailSQLite/AttachmentExtractor.swift
@@ -89,6 +89,38 @@ extension EmlxParser {
             throw MailSQLiteError.attachmentNotFound(name: attachmentName)
         }
 
+        // Step 5b (#66): if the matched MIME part has no inline body, the
+        // attachment binary lives in Apple Mail's sibling
+        // `Attachments/<rowId>/<part_id>/<filename>` cache. This happens
+        // for `.partial.emlx` messages (Mail.app extracts attachments to
+        // the external folder after IMAP fetch and strips the base64 body
+        // from the on-disk envelope to save space). Without this lookup
+        // we would silently `data.write(...)` an empty `Data()` and lie
+        // about success.
+        if part.decodedData.isEmpty {
+            if let externalURL = externalAttachmentURL(
+                emlxPath: path,
+                rowId: rowId,
+                attachmentName: attachmentName
+            ) {
+                let externalBytes = try Data(contentsOf: externalURL)
+                if externalBytes.count > attachmentInMemoryLimit {
+                    throw MailSQLiteError.attachmentTooLarge(
+                        name: attachmentName,
+                        size: externalBytes.count,
+                        limit: attachmentInMemoryLimit
+                    )
+                }
+                try externalBytes.write(to: destination, options: .atomic)
+                return
+            }
+            // Inline body empty AND no external file — treat as missing
+            // so the AppleScript fallback can have a turn (or surface the
+            // failure to the caller). NEVER write a 0-byte file: that's
+            // the silent-failure mode bug #66 was filed for.
+            throw MailSQLiteError.attachmentNotFound(name: attachmentName)
+        }
+
         // Size guard — large parts fall through to AppleScript streaming.
         let size = part.decodedData.count
         if size > attachmentInMemoryLimit {
@@ -102,6 +134,55 @@ extension EmlxParser {
         // Step 6: write decoded bytes. Use atomic write so partial files
         // never appear on disk on failure.
         try part.decodedData.write(to: destination, options: .atomic)
+    }
+
+    /// Look up the externalised attachment binary that Apple Mail stores
+    /// alongside a `.partial.emlx` message. Layout:
+    ///
+    /// ```
+    /// <hashDir>/Messages/<rowId>.partial.emlx          ← envelope (no body)
+    /// <hashDir>/Attachments/<rowId>/<part_id>/<filename>  ← real bytes
+    /// ```
+    ///
+    /// The `<part_id>` subfolder is opaque to us (Apple Mail picks it
+    /// based on the MIME tree at extraction time), so we walk every
+    /// subdirectory and return the first match by filename.
+    ///
+    /// Returns `nil` if the `Attachments/<rowId>/` directory doesn't exist
+    /// or contains no file matching `attachmentName`.
+    private static func externalAttachmentURL(
+        emlxPath: String,
+        rowId: Int,
+        attachmentName: String
+    ) -> URL? {
+        // emlxPath is `<hashDir>/Messages/<rowId>.{partial.,}emlx`. Walk up
+        // two levels to get the hash dir, then descend into Attachments.
+        let messagesDir = URL(fileURLWithPath: emlxPath).deletingLastPathComponent()
+        let hashDir = messagesDir.deletingLastPathComponent()
+        let attachmentsRoot = hashDir
+            .appendingPathComponent("Attachments", isDirectory: true)
+            .appendingPathComponent("\(rowId)", isDirectory: true)
+
+        let fm = FileManager.default
+        var isDir: ObjCBool = false
+        guard fm.fileExists(atPath: attachmentsRoot.path, isDirectory: &isDir), isDir.boolValue else {
+            return nil
+        }
+
+        // Each subdirectory is one MIME part; the file name inside should
+        // match `attachmentName` byte-for-byte.
+        guard let partIds = try? fm.contentsOfDirectory(atPath: attachmentsRoot.path) else {
+            return nil
+        }
+        for partId in partIds {
+            let candidate = attachmentsRoot
+                .appendingPathComponent(partId, isDirectory: true)
+                .appendingPathComponent(attachmentName)
+            if fm.fileExists(atPath: candidate.path) {
+                return candidate
+            }
+        }
+        return nil
     }
 
     /// First-match predicate: part's resolved filename equals request, or

--- a/Tests/MailSQLiteTests/AttachmentExtractorTests.swift
+++ b/Tests/MailSQLiteTests/AttachmentExtractorTests.swift
@@ -459,4 +459,178 @@ final class AttachmentExtractorTests: XCTestCase {
             }
         }
     }
+
+    // MARK: - Scenario (#66): .partial.emlx with externalised attachments
+
+    /// Build a `.partial.emlx` whose MIME structure declares an attachment
+    /// with the given filename but carries an empty body — Apple Mail's
+    /// pattern for IMAP messages whose binary parts have been extracted to
+    /// the sibling `Attachments/<rowId>/<part_id>/` folder.
+    ///
+    /// Returns the `(mailboxURL, attachmentsDir)` tuple. `attachmentsDir` is
+    /// the location where the caller can drop the externalised files
+    /// (e.g. `<attachmentsDir>/2/<filename>`); the caller is responsible for
+    /// creating the per-part subdirectory.
+    private func installPartialEmlxWithStrippedAttachment(
+        rowId: Int,
+        attachmentFilename: String,
+        accountUUID: String = "ABCE3A85-06BE-43BC-9B84-2CA6F325612F",
+        mailboxLeaf: String = "INBOX",
+        storeUUID: String = "5FCC6F13-2CE3-48B1-907D-686244C0229A",
+        in root: URL
+    ) throws -> (mailboxURL: String, attachmentsDir: URL) {
+        let boundary = "stripped-boundary"
+        let rfc822 =
+            "From: alice@example.com\r\n"
+            + "To: bob@example.com\r\n"
+            + "Subject: stripped-attachment\r\n"
+            + "MIME-Version: 1.0\r\n"
+            + "Content-Type: multipart/mixed; boundary=\(boundary)\r\n"
+            + "\r\n"
+            + "--\(boundary)\r\n"
+            + "Content-Type: text/plain; charset=utf-8\r\n"
+            + "\r\n"
+            + "body text\r\n"
+            + "--\(boundary)\r\n"
+            + "Content-Type: application/pdf; name=\"\(attachmentFilename)\"\r\n"
+            + "Content-Disposition: attachment; filename=\"\(attachmentFilename)\"\r\n"
+            + "Content-Transfer-Encoding: base64\r\n"
+            + "\r\n"
+            + "\r\n"  // empty body — Apple Mail's stripped pattern
+            + "--\(boundary)--\r\n"
+        let body = Data(rfc822.utf8)
+        var emlx = Data("\(body.count)\n".utf8)
+        emlx.append(body)
+
+        let mailV10 = root.appendingPathComponent("Library/Mail/V10", isDirectory: true)
+        let dataHashDir = mailV10
+            .appendingPathComponent(accountUUID)
+            .appendingPathComponent("\(mailboxLeaf).mbox")
+            .appendingPathComponent(storeUUID)
+            .appendingPathComponent("Data/2/6/2", isDirectory: true)
+        let messagesDir = dataHashDir.appendingPathComponent("Messages", isDirectory: true)
+        try FileManager.default.createDirectory(at: messagesDir, withIntermediateDirectories: true)
+        try emlx.write(to: messagesDir.appendingPathComponent("\(rowId).partial.emlx"))
+
+        let attachmentsDir = dataHashDir
+            .appendingPathComponent("Attachments", isDirectory: true)
+            .appendingPathComponent("\(rowId)", isDirectory: true)
+
+        EnvelopeIndexReader.mailStoragePathOverride = mailV10.path
+        return ("ews://\(accountUUID)/\(mailboxLeaf)", attachmentsDir)
+    }
+
+    /// Happy path for #66: `.partial.emlx` declares the attachment but its
+    /// body is empty; the binary lives in `Attachments/<rowId>/<part_id>/`.
+    /// `saveAttachment` MUST consult the external folder and write the real
+    /// bytes — never produce a 0-byte file.
+    func testSaveAttachment_partialEmlxWithExternalAttachment_writesExternalBytes() throws {
+        let root = tempRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let rowId = 262100
+        let filename = "report.pdf"
+        let (mailboxURL, attachmentsDir) = try installPartialEmlxWithStrippedAttachment(
+            rowId: rowId,
+            attachmentFilename: filename,
+            in: root
+        )
+
+        // Drop a real binary at Attachments/<rowId>/2/<filename> (Apple
+        // Mail uses the part index as the subfolder name).
+        let partDir = attachmentsDir.appendingPathComponent("2", isDirectory: true)
+        try FileManager.default.createDirectory(at: partDir, withIntermediateDirectories: true)
+        let externalFile = partDir.appendingPathComponent(filename)
+        let realBytes = Data((0..<2048).map { UInt8($0 & 0xFF) })
+        try realBytes.write(to: externalFile)
+
+        let dest = root.appendingPathComponent("out.pdf")
+        try EmlxParser.saveAttachment(
+            rowId: rowId,
+            mailboxURL: mailboxURL,
+            attachmentName: filename,
+            destination: dest
+        )
+
+        let written = try Data(contentsOf: dest)
+        XCTAssertEqual(
+            written,
+            realBytes,
+            "saveAttachment must read from external Attachments/<rowId>/<part_id>/<filename>, not the empty inline body"
+        )
+        XCTAssertGreaterThan(
+            written.count,
+            0,
+            "0-byte write means the inline empty body still won — bug #66 not fixed"
+        )
+    }
+
+    /// Negative path for #66: `.partial.emlx` declares the attachment, its
+    /// body is empty, AND the external `Attachments/<rowId>/` folder does
+    /// not exist (e.g. user purged the cache). MUST throw
+    /// `attachmentNotFound` rather than silently writing 0 bytes.
+    func testSaveAttachment_partialEmlxNoExternal_throwsAttachmentNotFound() throws {
+        let root = tempRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let rowId = 262100
+        let filename = "report.pdf"
+        let (mailboxURL, _) = try installPartialEmlxWithStrippedAttachment(
+            rowId: rowId,
+            attachmentFilename: filename,
+            in: root
+        )
+        // Deliberately don't create the Attachments/<rowId>/ folder.
+
+        let dest = root.appendingPathComponent("out.pdf")
+        XCTAssertThrowsError(try EmlxParser.saveAttachment(
+            rowId: rowId,
+            mailboxURL: mailboxURL,
+            attachmentName: filename,
+            destination: dest
+        )) { error in
+            guard case MailSQLiteError.attachmentNotFound(let name) = error else {
+                XCTFail("expected attachmentNotFound, got \(error)")
+                return
+            }
+            XCTAssertEqual(name, filename)
+        }
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: dest.path),
+            "no partial / 0-byte file should be left behind on attachmentNotFound"
+        )
+    }
+
+    /// Mirror of the happy path but exercising the external-folder match
+    /// against the legacy `Content-Type: name` parameter (some senders
+    /// only set `name=`, not `Content-Disposition: filename=`).
+    func testSaveAttachment_partialEmlxExternalLookup_matchesViaContentTypeName() throws {
+        let root = tempRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let rowId = 262200
+        let filename = "scan.pdf"
+        let (mailboxURL, attachmentsDir) = try installPartialEmlxWithStrippedAttachment(
+            rowId: rowId,
+            attachmentFilename: filename,
+            in: root
+        )
+
+        // Try a non-default part subfolder index ("3" instead of "2") to
+        // confirm the lookup walks all subfolders, not just /2/.
+        let partDir = attachmentsDir.appendingPathComponent("3", isDirectory: true)
+        try FileManager.default.createDirectory(at: partDir, withIntermediateDirectories: true)
+        let bytes = Data("PDF body bytes".utf8)
+        try bytes.write(to: partDir.appendingPathComponent(filename))
+
+        let dest = root.appendingPathComponent("out.pdf")
+        try EmlxParser.saveAttachment(
+            rowId: rowId,
+            mailboxURL: mailboxURL,
+            attachmentName: filename,
+            destination: dest
+        )
+
+        XCTAssertEqual(try Data(contentsOf: dest), bytes)
+    }
 }


### PR DESCRIPTION
Refs #66

## Summary

`EmlxParser.saveAttachment` was silently writing 0-byte files (and lying about success) when Apple Mail had stripped a message to `.partial.emlx` — the MIME structure still declared the attachment but the base64 body was empty because the binary lives in the sibling `Attachments/<rowId>/<part_id>/<filename>` cache. This was a separate failure mode from #24 (which addressed `list_attachments` returning stale entries).

Fix: when the matched MIME part has empty `decodedData`, walk `<hashDir>/Attachments/<rowId>/*/<filename>` and prefer the external bytes; if neither inline nor external file exists, throw `attachmentNotFound` so the AppleScript fallback (or the caller) surfaces the failure rather than reporting false success. The 100 MB size guard is reapplied to externalised bytes.

Architecturally: the SQLite + .emlx fast path now handles `.partial.emlx` end-to-end; the AppleScript fallback at `Server.swift:1017` is no longer reached for this common pattern.

## Verification

- ✓ `swift test` → **288 tests, 0 failures, 8 skipped** (3 new regression tests, all GREEN)
- ✓ Real-world smoke test: invoked the rebuilt release binary against the literal reporter reproduction (message id `265684`, mailbox `收件匣`). File written = 1,749,793 bytes, SHA `6221f771fd3e028afae217a3299eddfaa7c99409` — byte-identical to Mail.app's external cache. Pre-fix v2.7.0 binary on the same call wrote 0 bytes.
- See [issue #66 verify comment](https://github.com/PsychQuant/che-apple-mail-mcp/issues/66#issuecomment-4366879472) for full ensemble + smoke test transcript.

## Checklist

- [x] Diagnose ✓
- [x] Implement (1 commit, 258 insertions / 0 deletions / 3 files)
- [x] Verify ✓ (inline ensemble + real-world smoke test PASS)
- [ ] **Pending: human review of this PR + `/idd-close #66` after merge**

## Files changed

```
 CHANGELOG.md                                       |   3 +
 Sources/MailSQLite/AttachmentExtractor.swift       |  81 ++++++++++
 Tests/MailSQLiteTests/AttachmentExtractorTests.swift | 174 +++++++++++++++++
 3 files changed, 258 insertions(+)
```

## Related

- Sibling fix to #24 (which fixed `list_attachments` stale metadata; same architectural neighborhood, distinct failure mode)
- Tier 2 AppleScript fallback path unchanged
- `list_attachments_batch` (#25 follow-up) still has its own #24-class bug — out of scope for this PR

## Notes

- 4 P3 findings noted in verify comment are pre-existing trust-boundary observations (path traversal, symlink follow) that already apply to the inline-decode path and the AppleScript path. Not regressions introduced here.
- No public API surface change. No JSON-RPC schema change. Helper `externalAttachmentURL` is `private static`.

---
🤖 Generated by `/idd-all`. **Do NOT add `Closes #66` trailer** — IDD discipline requires manual `/idd-close` after merge to enforce checklist gate + closing summary.