### PR TITLE
perf: log SQLite fast-path fallback to stderr (#69)

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,36 @@ claude
 
 ---
 
+## Performance & Storage
+
+### SQLite + .emlx fast path
+
+Read tools (`get_email`, `get_emails_batch`, `get_email_headers`, `get_email_source`, `get_email_metadata`, `search_emails`, `list_attachments`, `save_attachment`) prefer Apple Mail's local Envelope Index (SQLite) and on-disk `.emlx` message files over AppleScript IPC. This is **10–100× faster** for large reads (e.g., archiving hundreds of messages).
+
+The fast path requires:
+
+- Full Disk Access granted to the host process (System Settings → Privacy & Security → Full Disk Access)
+- Apple Mail's local store at `~/Library/Mail/V10/...`
+- Message has been synced to local `.emlx` storage
+
+### EWS / Exchange accounts intentionally bypass the fast path
+
+Exchange (EWS) accounts in Apple Mail **do not materialize `.emlx` files** — message bodies live on the server and are fetched on demand. For these accounts, all read tools transparently fall back to AppleScript IPC, which is correct but slower. Symptoms:
+
+- A bulk fetch of 500 EWS messages will be noticeably slower than 500 IMAP/Gmail messages
+- This is **not a bug** — it's an Apple Mail storage architecture constraint (see [#9](https://github.com/PsychQuant/che-apple-mail-mcp/issues/9))
+
+### Diagnosing fast-path bypass
+
+When the fast path fails for a non-EWS account, the failure is logged to stderr (since [#69](https://github.com/PsychQuant/che-apple-mail-mcp/issues/69)). Run the binary in a terminal and watch stderr to distinguish:
+
+- `EnvelopeIndexReader init failed: ...` — DB unreachable (commonly: Full Disk Access missing)
+- `SQLite get_email fast path failed for rowId=N: ...` — per-message failure (e.g., `.partial.emlx` only, malformed MIME, file not yet synced)
+
+Both cases transparently fall through to AppleScript with `... falling through to AppleScript` in the log line, so behavior is preserved while observability is restored.
+
+---
+
 ## Troubleshooting
 
 | Problem | Solution |
@@ -336,13 +366,15 @@ claude
 | Not allowed to send Apple events | Add permissions in System Settings > Automation |
 | Mail.app not responding | Ensure Mail.app is running with configured accounts |
 | Commands timing out | Large mailboxes take longer; try specific searches |
+| Bulk fetch slower than expected | Watch stderr for `... falling through to AppleScript` lines. EWS/Exchange accounts always fall back (see [Performance & Storage](#performance--storage)); other accounts logging fallback indicate a fixable .emlx issue |
 
 ---
 
 ## Technical Details
 
 - **Framework**: [MCP Swift SDK](https://github.com/modelcontextprotocol/swift-sdk) v0.10.0
-- **Automation**: AppleScript via `NSAppleScript`
+- **Read path**: SQLite (Envelope Index) + `.emlx` file parser, with AppleScript fallback for EWS / unparseable `.emlx`
+- **Write/state path**: AppleScript via `NSAppleScript`
 - **Transport**: stdio
 - **Platform**: macOS 13.0+ (Ventura and later)
 

--- a/README.md
+++ b/README.md
@@ -332,7 +332,20 @@ claude
 
 ### SQLite + .emlx fast path
 
-Read tools (`get_email`, `get_emails_batch`, `get_email_headers`, `get_email_source`, `get_email_metadata`, `search_emails`, `list_attachments`, `save_attachment`) prefer Apple Mail's local Envelope Index (SQLite) and on-disk `.emlx` message files over AppleScript IPC. This is **10–100× faster** for large reads (e.g., archiving hundreds of messages).
+Most read tools prefer Apple Mail's local Envelope Index (SQLite) and on-disk `.emlx` message files over AppleScript IPC, with transparent AppleScript fallback when the SQLite path can't satisfy a request:
+
+| Tool | SQLite/.emlx path | AppleScript fallback |
+|------|------------------|----------------------|
+| `get_email` | ✓ | ✓ on any error |
+| `get_emails_batch` | ✓ (per item) | ✓ (per item) |
+| `get_email_headers` | ✓ | ✓ on any error |
+| `get_email_source` | ✓ | ✓ on any error |
+| `search_emails` | ✓ | ✓ when reader unavailable |
+| `list_attachments` | ✓ | ✓ on any error |
+| `save_attachment` | ✓ | ✓ on any error |
+| `get_email_metadata` | ✓ | ⚠ does **not** fall back today (see [#69](https://github.com/PsychQuant/che-apple-mail-mcp/issues/69) follow-up) |
+
+For `save_attachment`'s read path the fast path is **10–100× faster** than AppleScript (per [#12](https://github.com/PsychQuant/che-apple-mail-mcp/issues/12) measurements). Other tools' speedup ratios depend on request shape; in general, large bulk reads see the biggest gain.
 
 The fast path requires:
 
@@ -342,7 +355,7 @@ The fast path requires:
 
 ### EWS / Exchange accounts intentionally bypass the fast path
 
-Exchange (EWS) accounts in Apple Mail **do not materialize `.emlx` files** — message bodies live on the server and are fetched on demand. For these accounts, all read tools transparently fall back to AppleScript IPC, which is correct but slower. Symptoms:
+Exchange (EWS) accounts in Apple Mail **do not materialize `.emlx` files** — message bodies live on the server and are fetched on demand. For these accounts, the read tools listed above as having an AppleScript fallback transparently degrade to AppleScript IPC (which is correct but slower); `get_email_metadata` will surface the error today (see follow-up). Symptoms:
 
 - A bulk fetch of 500 EWS messages will be noticeably slower than 500 IMAP/Gmail messages
 - This is **not a bug** — it's an Apple Mail storage architecture constraint (see [#9](https://github.com/PsychQuant/che-apple-mail-mcp/issues/9))

--- a/Sources/CheAppleMailMCP/Server.swift
+++ b/Sources/CheAppleMailMCP/Server.swift
@@ -22,9 +22,18 @@ class CheAppleMailMCPServer {
         // Initialize SQLite reader (optional — falls back to AppleScript if unavailable)
         // Only open the DB connection here; account mapping is built lazily on first search
         // to avoid blocking server startup with AppleScript calls.
+        //
+        // Init failure surfaces to stderr so users can diagnose silent perf
+        // degradation (#69 — without this log, every read tool silently
+        // bypasses the SQLite + .emlx fast path with no observable cause).
         do {
             self.indexReader = try EnvelopeIndexReader(databasePath: EnvelopeIndexReader.defaultDatabasePath)
         } catch {
+            let message = "EnvelopeIndexReader init failed: "
+                + "\(error.localizedDescription); "
+                + "all read tools will use AppleScript fallback path "
+                + "(slower; expected for EWS accounts, see README).\n"
+            FileHandle.standardError.write(Data(message.utf8))
             self.indexReader = nil
         }
 
@@ -784,7 +793,13 @@ class CheAppleMailMCPServer {
                         return formatJSON(result)
                     }
                 } catch {
-                    // Fall through to AppleScript
+                    // Log the cause so silent fallbacks are observable, then
+                    // fall through to AppleScript (#69 — mirrors the
+                    // save_attachment fast-path logging at Server.swift:1003).
+                    let message = "SQLite get_email fast path failed for "
+                        + "rowId=\(rowId): \(error.localizedDescription); "
+                        + "falling through to AppleScript\n"
+                    FileHandle.standardError.write(Data(message.utf8))
                 }
             }
             let email = try await mailController.getEmail(id: id, mailbox: mailbox, accountName: accountName, format: format)
@@ -1127,10 +1142,21 @@ class CheAppleMailMCPServer {
                   let accountName = arguments["account_name"]?.stringValue else {
                 throw MailError.invalidParameter("mailbox, and account_name are required")
             }
-            if let reader = indexReader, let rowId = Int(id),
-               let mailboxUrl = try? reader.mailboxURL(forMessageId: rowId) {
-                if let headers = try? EmlxParser.readHeaders(rowId: rowId, mailboxURL: mailboxUrl) {
-                    return headers
+            // Convert nested `try?` to do/catch so SQLite-path failures are
+            // observable on stderr (#69 — pre-fix `try?` swallowed the cause
+            // silently). Behavior is unchanged: any error still falls through
+            // to AppleScript.
+            if let reader = indexReader, let rowId = Int(id) {
+                do {
+                    if let mailboxUrl = try reader.mailboxURL(forMessageId: rowId) {
+                        let headers = try EmlxParser.readHeaders(rowId: rowId, mailboxURL: mailboxUrl)
+                        return headers
+                    }
+                } catch {
+                    let message = "SQLite get_email_headers fast path failed for "
+                        + "rowId=\(rowId): \(error.localizedDescription); "
+                        + "falling through to AppleScript\n"
+                    FileHandle.standardError.write(Data(message.utf8))
                 }
             }
             return try await mailController.getEmailHeaders(id: id, mailbox: mailbox, accountName: accountName)
@@ -1141,10 +1167,19 @@ class CheAppleMailMCPServer {
                   let accountName = arguments["account_name"]?.stringValue else {
                 throw MailError.invalidParameter("mailbox, and account_name are required")
             }
-            if let reader = indexReader, let rowId = Int(id),
-               let mailboxUrl = try? reader.mailboxURL(forMessageId: rowId) {
-                if let source = try? EmlxParser.readSource(rowId: rowId, mailboxURL: mailboxUrl) {
-                    return source
+            // See get_email_headers above for #69 context — same try?-to-catch
+            // refactor for stderr observability.
+            if let reader = indexReader, let rowId = Int(id) {
+                do {
+                    if let mailboxUrl = try reader.mailboxURL(forMessageId: rowId) {
+                        let source = try EmlxParser.readSource(rowId: rowId, mailboxURL: mailboxUrl)
+                        return source
+                    }
+                } catch {
+                    let message = "SQLite get_email_source fast path failed for "
+                        + "rowId=\(rowId): \(error.localizedDescription); "
+                        + "falling through to AppleScript\n"
+                    FileHandle.standardError.write(Data(message.utf8))
                 }
             }
             return try await mailController.getEmailSource(id: id, mailbox: mailbox, accountName: accountName)
@@ -1263,7 +1298,15 @@ class CheAppleMailMCPServer {
                             continue
                         }
                     } catch {
-                        // Fall through to AppleScript
+                        // Log per-item failure with rowId so partial-failure
+                        // diagnostics are observable in batch fetches (#69 —
+                        // an archive of N emails may have M legitimate EWS
+                        // fallbacks vs K silent Gmail failures; without rowId
+                        // logging users can't tell them apart).
+                        let message = "SQLite get_emails_batch fast path failed for "
+                            + "rowId=\(rowId): \(error.localizedDescription); "
+                            + "falling through to AppleScript for this item\n"
+                        FileHandle.standardError.write(Data(message.utf8))
                     }
                 }
                 // Fallback to AppleScript


### PR DESCRIPTION
Refs #69

## Summary

Add stderr logging at 5 SQLite-fast-path sites in `Server.swift`, mirroring `save_attachment`'s precedent (#12 closed). Plus README documentation explaining EWS / Exchange accounts intentionally bypass the fast path.

**The original issue premise was wrong**: the SQLite + .emlx fast path is already implemented for all 5 read tools. The actual gap is observability — silent fallbacks made degradation invisible. This PR scopes the fix to that real gap.

## Changes

- **Server.swift:28** — log `EnvelopeIndexReader` init failure (was silent)
- **Server.swift get_email (line 786)** — log catch path with rowId
- **Server.swift get_emails_batch (line 1268)** — log per-item failure with rowId
- **Server.swift get_email_headers / get_email_source** — convert `try?` to `do/catch` with stderr log; behavior unchanged
- **README.md** — new "Performance & Storage" section explaining EWS fallback + how to read stderr logs

## Verification

**Build**: `swift build` clean (only pre-existing deprecation warnings unrelated to #69).

**Behavior preservation**: All 9 existing `FallbackTests` + `StartupTests` pass post-edit. The refactor of `try?` → `do/catch` preserves the fall-through-to-AppleScript path on any error.

**No new tests added** — matches #12 precedent (stderr side-effects not unit-tested in this repo). Smoke test path documented in the Implementation Complete comment.

## Out of scope (deferred sister concerns, see issue body)

- Hit/miss metrics surface (would be a Spectra change — new public API)
- Data-driven perf re-investigation after observability lands

## Checklist

- [x] Diagnose (revealed issue premise was incorrect; reframed scope)
- [x] Implement (1 commit, `cb9c073`)
- [ ] Verify (run `/idd-verify #69`)
- [ ] **Pending: human review of this PR + `/idd-close` after merge**

---
🤖 Generated by `/idd-all` (PR mode, unattended). **Do NOT add `Closes #69`** — IDD discipline requires manual `/idd-close` after merge to enforce checklist gate + closing summary.