### PR TITLE
fix(rfc822): header/body split returns absolute Data index, slice-safe (#72)

### DIFF
--- a/Sources/MailSQLite/RFC822Parser.swift
+++ b/Sources/MailSQLite/RFC822Parser.swift
@@ -10,34 +10,38 @@ public enum RFC822Parser {
     /// - Parameter data: Raw RFC 822 message data.
     /// - Returns: Dictionary mapping lowercase header names to decoded values.
     public static func parseHeaders(from data: Data) -> [String: String] {
-        guard let headerEnd = headerBodySplitOffset(in: data) else {
-            // No body separator found — treat entire data as headers
-            return parseHeaderBlock(data)
+        // findDoubleCRLF returns an absolute Data index (slice-safe per #72).
+        if let splitIdx = findDoubleCRLF(in: data) {
+            return parseHeaderBlock(data[data.startIndex..<splitIdx])
         }
-        let headerData = data[data.startIndex..<data.index(data.startIndex, offsetBy: headerEnd - data.startIndex - 4 >= 0 ? 0 : 0)]
-        // Find the \r\n\r\n boundary
-        let splitIdx = findDoubleCRLF(in: data)
-        if let idx = splitIdx {
-            return parseHeaderBlock(data[data.startIndex..<idx])
-        }
+        // No body separator found — treat entire data as headers.
         return parseHeaderBlock(data)
     }
 
-    /// Find the byte offset where the body begins (after \r\n\r\n or \n\n).
-    /// Returns the offset of the first byte of the body, or nil if not found.
+    /// Find the absolute Data index where the body begins (after `\r\n\r\n`
+    /// or `\n\n`). Returns an index suitable for `data[returnedIndex...]`,
+    /// or nil if no separator is found.
+    ///
+    /// **Slice safety (#72)**: `data` may be a slice with non-zero
+    /// `startIndex`. The returned value is an absolute Data index relative
+    /// to the original buffer — callers can write `data[offset...]` and
+    /// `data.endIndex` directly without manual `data.startIndex` arithmetic.
     public static func headerBodySplitOffset(in data: Data) -> Int? {
-        let bytes = Array(data)
         // Look for \r\n\r\n
-        for i in 0..<(bytes.count - 3) {
-            if bytes[i] == 0x0D && bytes[i+1] == 0x0A
-                && bytes[i+2] == 0x0D && bytes[i+3] == 0x0A {
-                return i + 4
+        if data.count >= 4 {
+            for i in data.startIndex..<(data.endIndex - 3) {
+                if data[i] == 0x0D && data[i + 1] == 0x0A
+                    && data[i + 2] == 0x0D && data[i + 3] == 0x0A {
+                    return i + 4
+                }
             }
         }
         // Fallback: look for \n\n (some messages use bare LF)
-        for i in 0..<(bytes.count - 1) {
-            if bytes[i] == 0x0A && bytes[i+1] == 0x0A {
-                return i + 2
+        if data.count >= 2 {
+            for i in data.startIndex..<(data.endIndex - 1) {
+                if data[i] == 0x0A && data[i + 1] == 0x0A {
+                    return i + 2
+                }
             }
         }
         return nil
@@ -45,18 +49,25 @@ public enum RFC822Parser {
 
     // MARK: - Private
 
+    /// Find the absolute Data index of the `\r\n\r\n` (or fallback `\n\n`)
+    /// separator. Returns the index of the **first** byte of the separator,
+    /// suitable for `data[..<returnedIndex]` to slice the headers.
+    ///
+    /// Honors `data.startIndex` (slice safety, #72).
     private static func findDoubleCRLF(in data: Data) -> Int? {
-        let bytes = Array(data)
-        for i in 0..<(bytes.count - 3) {
-            if bytes[i] == 0x0D && bytes[i+1] == 0x0A
-                && bytes[i+2] == 0x0D && bytes[i+3] == 0x0A {
-                return i
+        if data.count >= 4 {
+            for i in data.startIndex..<(data.endIndex - 3) {
+                if data[i] == 0x0D && data[i + 1] == 0x0A
+                    && data[i + 2] == 0x0D && data[i + 3] == 0x0A {
+                    return i
+                }
             }
         }
-        // Fallback: bare \n\n
-        for i in 0..<(bytes.count - 1) {
-            if bytes[i] == 0x0A && bytes[i+1] == 0x0A {
-                return i
+        if data.count >= 2 {
+            for i in data.startIndex..<(data.endIndex - 1) {
+                if data[i] == 0x0A && data[i + 1] == 0x0A {
+                    return i
+                }
             }
         }
         return nil

--- a/Tests/MailSQLiteTests/MIMEParserTests.swift
+++ b/Tests/MailSQLiteTests/MIMEParserTests.swift
@@ -379,4 +379,145 @@ final class MIMEParserTests: XCTestCase {
         let decoded = MIMEParser.decodeRFC5987("UTF-8''%E4%B8%AD%E6%96%87.pdf")
         XCTAssertEqual(decoded, "中文.pdf")
     }
+
+    // MARK: - Base64-encoded multipart parts (#72)
+
+    /// Single-layer multipart/alternative with base64-encoded HTML part.
+    /// Mirrors the simplest manifestation of #72 — the HTML body is
+    /// transferred as base64 and `parseBody` must decode it.
+    func testParseBodyMultipartAlternativeBase64HTMLOnly() {
+        let boundary = "----=_Part_b64_single"
+        let headers = ["content-type": "multipart/alternative; boundary=\"\(boundary)\""]
+        // base64 of "<html><body>Hello</body></html>"
+        let htmlBase64 = "PGh0bWw+PGJvZHk+SGVsbG88L2JvZHk+PC9odG1sPg=="
+        let body = """
+        ------=_Part_b64_single\r
+        Content-Type: text/plain; charset=utf-8\r
+        \r
+        Plain text version\r
+        ------=_Part_b64_single\r
+        Content-Type: text/html; charset=utf-8\r
+        Content-Transfer-Encoding: base64\r
+        \r
+        \(htmlBase64)\r
+        ------=_Part_b64_single--\r
+        """
+        let result = MIMEParser.parseBody(Data(body.utf8), headers: headers)
+        XCTAssertEqual(result.textBody, "Plain text version\r\n")
+        XCTAssertEqual(result.htmlBody, "<html><body>Hello</body></html>")
+    }
+
+    /// Nested multipart: outer multipart/mixed wraps an inner
+    /// multipart/alternative whose HTML part is base64-encoded.
+    /// Pattern emitted by Android Gmail (Message-ID `*@email.android.com`)
+    /// and the original reproducer for #72.
+    func testParseBodyNestedMultipartMixedWithAlternativeBase64HTML() {
+        let outer = "----=_Outer_mixed"
+        let inner = "----=_Inner_alt"
+        let headers = ["content-type": "multipart/mixed; boundary=\"\(outer)\""]
+        // base64 of "<html><body>Nested</body></html>"
+        let htmlBase64 = "PGh0bWw+PGJvZHk+TmVzdGVkPC9ib2R5PjwvaHRtbD4="
+        let body = """
+        ------=_Outer_mixed\r
+        Content-Type: multipart/alternative; boundary="\(inner)"\r
+        MIME-Version: 1.0\r
+        \r
+        ------=_Inner_alt\r
+        Content-Type: text/plain; charset=utf-8\r
+        \r
+        Plain text\r
+        ------=_Inner_alt\r
+        Content-Type: text/html; charset=utf-8\r
+        Content-Transfer-Encoding: base64\r
+        \r
+        \(htmlBase64)\r
+        ------=_Inner_alt--\r
+        ------=_Outer_mixed--\r
+        """
+        let result = MIMEParser.parseBody(Data(body.utf8), headers: headers)
+        XCTAssertEqual(result.textBody, "Plain text\r\n")
+        XCTAssertEqual(result.htmlBody, "<html><body>Nested</body></html>")
+        // Regression guard: htmlBody must not contain MIME-Version remnant.
+        XCTAssertFalse(result.htmlBody?.contains("MIME-Version") ?? false)
+        XCTAssertFalse(result.htmlBody?.contains("sion: 1.0") ?? false)
+    }
+
+    /// **Real reproducer for #72**:emlx-extracted Data slice with non-zero
+    /// `startIndex` exposes a Data-index-vs-array-index mismatch in
+    /// `RFC822Parser.headerBodySplitOffset` callers
+    /// (`EmailContent.readEmail`, `EmlxParser.readHeaders`,
+    /// `AttachmentExtractor`).
+    ///
+    /// The .emlx container is: `"<byteCount>\n<RFC822 bytes>"`.
+    /// `EmlxFormat.extractMessageData` returns a `Data` slice whose
+    /// `startIndex == byteCount-header-prefix-length`. Then
+    /// `headerBodySplitOffset(in: messageData)` does `Array(data)` → returns
+    /// a 0-based array index. Callers do `messageData[bodyOffset...]` which
+    /// is interpreted as **absolute** Data index, so the body slice is off
+    /// by `messageData.startIndex` bytes — exactly the symptom observed in
+    /// production (`html_body` starts with `"sion: 1.0\n\n<base64>"`,
+    /// the tail of `"MIME-Version: 1.0"` from the header block).
+    func testEmlxToBodyExtractionPreservesSliceStartIndex() throws {
+        // Synthetic .emlx: `"100\n" + RFC822 message`. The "100" prefix
+        // gives messageData.startIndex == 4.
+        let rfc822 = """
+        Content-Type: text/html; charset="utf-8"
+        Content-Transfer-Encoding: base64
+        MIME-Version: 1.0
+
+        PGh0bWw+PGJvZHk+SGVsbG88L2JvZHk+PC9odG1sPg==
+        """
+        let messageBytes = rfc822.replacingOccurrences(of: "\n", with: "\n").data(using: .utf8)!
+        let prefix = "\(messageBytes.count)\n".data(using: .utf8)!
+        var emlx = Data()
+        emlx.append(prefix)
+        emlx.append(messageBytes)
+
+        let messageData = try EmlxFormat.extractMessageData(from: emlx)
+        XCTAssertNotEqual(messageData.startIndex, 0,
+            "Slice from extractMessageData should retain non-zero startIndex")
+
+        // Mirror the EmailContent.readEmail flow.
+        let headers = RFC822Parser.parseHeaders(from: messageData)
+        XCTAssertEqual(headers["content-type"], "text/html; charset=\"utf-8\"")
+        XCTAssertEqual(headers["content-transfer-encoding"], "base64")
+        XCTAssertEqual(headers["mime-version"], "1.0")
+
+        guard let bodyOffset = RFC822Parser.headerBodySplitOffset(in: messageData) else {
+            XCTFail("Expected to find header/body split")
+            return
+        }
+        let bodyData = Data(messageData[bodyOffset...])
+
+        let parsed = MIMEParser.parseBody(bodyData, headers: headers)
+        // Regression guard: htmlBody must NOT contain the MIME-Version tail
+        // that production observed.
+        XCTAssertFalse(parsed.htmlBody?.contains("sion: 1.0") ?? false,
+            "htmlBody contains MIME-Version header tail: \(parsed.htmlBody ?? "<nil>")")
+        XCTAssertEqual(parsed.htmlBody, "<html><body>Hello</body></html>")
+    }
+
+    /// `text/plain` part transferred as base64 — covers the symmetric case
+    /// where the plain part (not just HTML) needs decoding.
+    func testParseBodyMultipartWithBase64TextPlain() {
+        let boundary = "----=_Part_b64_text"
+        let headers = ["content-type": "multipart/alternative; boundary=\"\(boundary)\""]
+        // base64 of "Hello, world!"
+        let textBase64 = "SGVsbG8sIHdvcmxkIQ=="
+        let body = """
+        ------=_Part_b64_text\r
+        Content-Type: text/plain; charset=utf-8\r
+        Content-Transfer-Encoding: base64\r
+        \r
+        \(textBase64)\r
+        ------=_Part_b64_text\r
+        Content-Type: text/html; charset=utf-8\r
+        \r
+        <p>HTML version</p>\r
+        ------=_Part_b64_text--\r
+        """
+        let result = MIMEParser.parseBody(Data(body.utf8), headers: headers)
+        XCTAssertEqual(result.textBody, "Hello, world!")
+        XCTAssertEqual(result.htmlBody, "<p>HTML version</p>\r\n")
+    }
 }


### PR DESCRIPTION
Refs #72

## Summary

Fix `RFC822Parser.headerBodySplitOffset` / `findDoubleCRLF` to return absolute Data indices instead of array-relative indices. This eliminates a slice-safety bug where `EmailContent.readEmail` (and other callers using `EmlxFormat.extractMessageData`'s return value) sliced body data starting `messageData.startIndex` bytes too early.

## Diagnosis chain
- Issue: [#72](https://github.com/PsychQuant/che-apple-mail-mcp/issues/72) — bug filed with reproducer + AUP impact
- Diagnosis: [#issuecomment-4401900593](https://github.com/PsychQuant/che-apple-mail-mcp/issues/72#issuecomment-4401900593) — initial hypothesis (parseMultipart String round-trip) was wrong; corrected during TDD
- Plan: [#issuecomment-4401990931](https://github.com/PsychQuant/che-apple-mail-mcp/issues/72#issuecomment-4401990931) — Plan tier approved via EnterPlanMode

## Root cause

`Array(data)` flattens any Data slice to a 0-indexed array. The functions returned that array-relative index. Callers like `messageData[bodyOffset...]` interpreted the integer as **absolute** Data index. For sliced inputs (e.g., `EmlxFormat.extractMessageData` returns `data[messageStart..<end]`), the body slice was `messageData.startIndex` bytes too early — the tail of the final header line bled into the body.

For #272572's single-part `text/html` + `base64` message, this surfaced as `html_body == "sion: 1.0\n\n<base64>"` — the tail of `MIME-Version: 1.0` plus undecoded base64. Downstream LLM agents then ingest a long random-looking blob and trigger Anthropic AUP false-positives that block entire archive-mail pipelines.

## Test plan
- [x] `testEmlxToBodyExtractionPreservesSliceStartIndex` — synthetic emlx with `"100\n"` prefix exposes the slice-index mismatch without using PII
- [x] `testParseBodyMultipartAlternativeBase64HTMLOnly` — single-layer multipart + base64 HTML
- [x] `testParseBodyNestedMultipartMixedWithAlternativeBase64HTML` — Android-Gmail-style nested multipart
- [x] `testParseBodyMultipartWithBase64TextPlain` — symmetric base64 text/plain case
- [x] Full `MailSQLiteTests`: 156 pass, 1 skipped, 0 failures
- [ ] Manual end-to-end: `get_email(id=272572, format='text')` against real .emlx — pending repo install + smoke

## Sister issues
- #73 — `MailController.extractHTMLBody` separate AppleScript-fallback path bug (same root-cause family); not bundled per Plan D2 (will reassess after this lands)
- #74 — quoted-printable 8-bit char (speculative tracking)

## Checklist
- [x] RED test
- [x] GREEN refactor (headerBodySplitOffset + findDoubleCRLF + parseHeaders cleanup)
- [x] Full regression suite passes
- [ ] **Pending: human review + manual /idd-close after merge**

---

**Do NOT add `Closes #72`** — IDD discipline requires manual `/idd-close` after merge for closing summary + checklist gate.