### PR TITLE
docs(composing): unify sanitize_links schema descriptions across 4 tools (Refs #86)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **`sanitize_links` schema description consistency across 4 composing tools** ([#86](https://github.com/PsychQuant/che-apple-mail-mcp/issues/86)). Cluster A shipped `sanitize_links` opt-in but only `compose_email`'s schema description carried the XSS rationale; `create_draft`, `reply_email`, `forward_email` had a truncated "Same semantics as compose_email" pointer. LLMs tool-selecting against those 3 schemas couldn't see the security-relevant note. All 4 descriptions now use identical unified text that (a) repeats the XSS rationale (defends against `[click](javascript:...)`, `data:`, `file:`, `vbscript:`), (b) explicitly states "only applies when `format` is `markdown`; no effect in plain/html modes" — preventing the silent-no-op trap where a caller passes `format: "html", sanitize_links: true` and assumes protection. Pure schema text change, zero behavior impact. swift test 313/0/8 unchanged.
+
 ## [2.8.0] - 2026-05-11
 
 ### Added

--- a/Sources/CheAppleMailMCP/Server.swift
+++ b/Sources/CheAppleMailMCP/Server.swift
@@ -236,7 +236,7 @@ class CheAppleMailMCPServer {
                         "bcc": .object(["type": .string("array"), "items": .object(["type": .string("string")]), "description": .string("BCC recipients (optional)")]),
                         "attachments": .object(["type": .string("array"), "items": .object(["type": .string("string")]), "description": .string("Absolute file paths to attach (optional)")]),
                         "format": .object(["type": .string("string"), "enum": .array([.string("plain"), .string("markdown"), .string("html")]), "description": .string("Body format. 'plain' (default) passes body as-is; 'markdown' renders bold/italic/code/links/lists; 'html' inserts raw HTML.")]),
-                        "sanitize_links": .object(["type": .string("boolean"), "description": .string("If true, markdown-mode link URLs whose scheme is not http/https/mailto/tel are rendered as plain text (no anchor) — defends against `[click](javascript:...)` XSS injection. Default false (preserves backward compat). Has no effect in plain or html mode (html mode is by-design caller-trusted; you must sanitize your own raw HTML).")])
+                        "sanitize_links": .object(["type": .string("boolean"), "description": .string("If true AND `format` is `markdown`, link URLs whose scheme is not in {http, https, mailto, tel} are rendered as plain text (no `<a>` wrapper) — defends against `[click](javascript:...)` and `data:`/`file:`/`vbscript:` XSS injection. Default false (preserves backward compat). No effect when `format` is `plain` (no link parsing happens) or `html` (caller-trusted raw HTML — you must sanitize your own anchors).")])
                     ]),
                     "required": .array([.string("to"), .string("subject"), .string("body")])
                 ])
@@ -256,7 +256,7 @@ class CheAppleMailMCPServer {
                         "attachments": .object(["type": .string("array"), "items": .object(["type": .string("string")]), "description": .string("Absolute file paths to attach to the reply.")]),
                         "save_as_draft": .object(["type": .string("boolean"), "description": .string("If true, save the reply as a draft instead of sending it (default: false). Use when you want a human to review before send.")]),
                         "format": .object(["type": .string("string"), "enum": .array([.string("plain"), .string("markdown"), .string("html")]), "description": .string("Body format. 'plain' (default) prepends the user body to the original message quoted with RFC 3676 `> ` line prefix — preserves signature + rich text; 'markdown'/'html' produce rich text user body but wrap the original's plain-text (HTML-escaped) in a `<blockquote>` because AppleScript denies html-content read on current macOS — signature lost.")]),
-                        "sanitize_links": .object(["type": .string("boolean"), "description": .string("If true, markdown-mode link URLs whose scheme is not http/https/mailto/tel are rendered as plain text (no anchor). Default false. Same semantics as compose_email.")])
+                        "sanitize_links": .object(["type": .string("boolean"), "description": .string("If true AND `format` is `markdown`, link URLs whose scheme is not in {http, https, mailto, tel} are rendered as plain text (no `<a>` wrapper) — defends against `[click](javascript:...)` and `data:`/`file:`/`vbscript:` XSS injection. Default false (preserves backward compat). No effect when `format` is `plain` (no link parsing happens) or `html` (caller-trusted raw HTML — you must sanitize your own anchors).")])
                     ]),
                     "required": .array([.string("id"), .string("mailbox"), .string("account_name"), .string("body")])
                 ])
@@ -273,7 +273,7 @@ class CheAppleMailMCPServer {
                         "to": .object(["type": .string("array"), "items": .object(["type": .string("string")]), "description": .string("Recipients to forward to")]),
                         "body": .object(["type": .string("string"), "description": .string("Optional message to add (interpreted according to 'format')")]),
                         "format": .object(["type": .string("string"), "enum": .array([.string("plain"), .string("markdown"), .string("html")]), "description": .string("Body format. 'plain' (default), 'markdown', or 'html'.")]),
-                        "sanitize_links": .object(["type": .string("boolean"), "description": .string("If true, markdown-mode link URLs whose scheme is not http/https/mailto/tel are rendered as plain text (no anchor). Default false. Same semantics as compose_email.")])
+                        "sanitize_links": .object(["type": .string("boolean"), "description": .string("If true AND `format` is `markdown`, link URLs whose scheme is not in {http, https, mailto, tel} are rendered as plain text (no `<a>` wrapper) — defends against `[click](javascript:...)` and `data:`/`file:`/`vbscript:` XSS injection. Default false (preserves backward compat). No effect when `format` is `plain` (no link parsing happens) or `html` (caller-trusted raw HTML — you must sanitize your own anchors).")])
                     ]),
                     "required": .array([.string("id"), .string("mailbox"), .string("account_name"), .string("to")])
                 ])
@@ -302,7 +302,7 @@ class CheAppleMailMCPServer {
                         "body": .object(["type": .string("string"), "description": .string("Email body content (interpreted according to 'format')")]),
                         "attachments": .object(["type": .string("array"), "items": .object(["type": .string("string")]), "description": .string("Absolute file paths to attach (optional)")]),
                         "format": .object(["type": .string("string"), "enum": .array([.string("plain"), .string("markdown"), .string("html")]), "description": .string("Body format. 'plain' (default) passes body as-is; 'markdown' renders bold/italic/code/links/lists; 'html' inserts raw HTML.")]),
-                        "sanitize_links": .object(["type": .string("boolean"), "description": .string("If true, markdown-mode link URLs whose scheme is not http/https/mailto/tel are rendered as plain text (no anchor). Default false. Same semantics as compose_email.")])
+                        "sanitize_links": .object(["type": .string("boolean"), "description": .string("If true AND `format` is `markdown`, link URLs whose scheme is not in {http, https, mailto, tel} are rendered as plain text (no `<a>` wrapper) — defends against `[click](javascript:...)` and `data:`/`file:`/`vbscript:` XSS injection. Default false (preserves backward compat). No effect when `format` is `plain` (no link parsing happens) or `html` (caller-trusted raw HTML — you must sanitize your own anchors).")])
                     ]),
                     "required": .array([.string("to"), .string("subject"), .string("body")])
                 ])


### PR DESCRIPTION
Refs #86

## Summary

Unifies `sanitize_links` schema descriptions across all 4 composing tools (`compose_email`, `create_draft`, `reply_email`, `forward_email`) — cluster A shipped the parameter but only `compose_email` carried the XSS rationale; the other 3 had a truncated "Same semantics as compose_email" pointer.

Two gaps closed:
1. **XSS rationale repeated** verbatim across all 4 descriptions so tool-selecting LLMs see the security context everywhere
2. **Mode-restriction stated explicitly** (`only applies when format is markdown; no effect in plain/html`) — prevents the silent-no-op trap

## Test status

`swift test` → **313/0/8** (unchanged from v2.8.0 baseline; this is pure schema text, no behavior change).

`grep` verification:
- `If true AND \`format\` is \`markdown\`` — **4 matches** (one per composing tool, all identical text)
- `Same semantics as compose_email` — **0 matches** (stale fragments gone)

## Commits

`fc64402` — docs(composing): unify sanitize_links schema descriptions across 4 tools (#86)

---
Generated by `/idd-implement #86` (Simple complexity). **Do NOT add 'Closes #86' trailer** — IDD discipline requires manual `/idd-close` after merge.
