### PR TITLE
cluster: 3 chore cleanups — dead script vars / deprecated text() / assertion tightening (Refs #82 #83 #84)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Chore cluster: 3 sister bugs from cluster A's Step 5.7 sweep** ([#82](https://github.com/PsychQuant/che-apple-mail-mcp/issues/82), [#83](https://github.com/PsychQuant/che-apple-mail-mcp/issues/83), [#84](https://github.com/PsychQuant/che-apple-mail-mcp/issues/84)). (#82) Removed 4 dead `let script = ...` AppleScript declarations in `MailController.swift` (`getAccountInfo`, `listMailboxes`, `listEmails`, `listAttachments`) — each shadowed by a more specific `*Script` variable downstream and never executed; warning count drops by 4. (#83) Migrated 3 deprecated `text(_:metadata:)` MCP SDK factory calls in `Server.swift` to the canonical `.text(text:annotations:_meta:)` enum case; semantically identical (deprecated factory forwards to same case with `annotations: nil, _meta: nil`); deprecation-warning count drops by 3. (#84) Retrofitted 31 of 57 lenient `XCTAssertTrue(script.contains(...))` assertions in `MailControllerComposeTests.swift` to `assertOrdered(script, needle, between:, and:)` — defends against regressions that move a property outside its expected `tell ... end tell` block (which previously passed contains() silently but crashed Mail.app at runtime). Targets compose/createDraft recipient + html content, reply/forward plain + markdown + html branches. Remaining 24 stay lenient with documented rationale (boundary tokens, top-level dispatch verbs, first-occurrence substring collisions). Pure test-tightening; production behavior unaffected. swift test 321/0/8 unchanged.
+
 ## [2.8.2] - 2026-05-11
 
 ### Added

--- a/Sources/CheAppleMailMCP/AppleScript/MailController.swift
+++ b/Sources/CheAppleMailMCP/AppleScript/MailController.swift
@@ -120,13 +120,6 @@ actor MailController {
 
     /// Get account details
     func getAccountInfo(accountName: String) throws -> [String: Any] {
-        let script = """
-        tell application "Mail"
-            set acc to account "\(escapeForAppleScript(accountName))"
-            return {|name|:name of acc, |enabled|:enabled of acc, |email|:email addresses of acc}
-        end tell
-        """
-
         let enabledScript = """
         tell application "Mail"
             get enabled of account "\(escapeForAppleScript(accountName))"
@@ -153,33 +146,6 @@ actor MailController {
 
     /// List mailboxes for an account
     func listMailboxes(accountName: String? = nil) throws -> [[String: Any]] {
-        let script: String
-        if let account = accountName {
-            script = """
-            tell application "Mail"
-                set mbList to {}
-                repeat with mb in mailboxes of account "\(escapeForAppleScript(account))"
-                    set mbInfo to {|name|:name of mb, |unreadCount|:unread count of mb, |messageCount|:count of messages of mb}
-                    set end of mbList to mbInfo
-                end repeat
-                return mbList
-            end tell
-            """
-        } else {
-            script = """
-            tell application "Mail"
-                set mbList to {}
-                repeat with acc in accounts
-                    repeat with mb in mailboxes of acc
-                        set mbInfo to {|name|:name of mb, |account|:name of acc, |unreadCount|:unread count of mb}
-                        set end of mbList to mbInfo
-                    end repeat
-                end repeat
-                return mbList
-            end tell
-            """
-        }
-
         // Simplified: get mailbox names
         let namesScript: String
         if let account = accountName {
@@ -238,19 +204,6 @@ actor MailController {
 
     /// List emails in a mailbox
     func listEmails(mailbox: String, accountName: String, limit: Int = 50) throws -> [[String: Any]] {
-        let script = """
-        tell application "Mail"
-            set mb to \(mailboxRef(mailbox, account: accountName))
-            set msgs to messages 1 thru \(limit) of mb
-            set msgList to {}
-            repeat with msg in msgs
-                set msgInfo to {|id|:id of msg, |subject|:subject of msg, |sender|:sender of msg, |dateReceived|:date received of msg as string, |read|:read status of msg}
-                set end of msgList to msgInfo
-            end repeat
-            return msgList
-        end tell
-        """
-
         // Simplified approach: get basic info (clamp limit to actual message count)
         let subjectsScript = """
         tell application "Mail"
@@ -998,18 +951,6 @@ actor MailController {
     /// List attachments of an email
     func listAttachments(id: String, mailbox: String, accountName: String) throws -> [[String: Any]] {
         let ref = msgRef(id, mailbox: mailbox, account: accountName)
-        let script = """
-        tell application "Mail"
-            set msg to \(ref)
-            set attachmentList to {}
-            repeat with att in mail attachments of msg
-                set attInfo to {|name|:name of att, |size|:file size of att}
-                set end of attachmentList to attInfo
-            end repeat
-            return attachmentList
-        end tell
-        """
-
         let namesScript = """
         tell application "Mail"
             get name of every mail attachment of \(ref)

--- a/Sources/CheAppleMailMCP/Server.swift
+++ b/Sources/CheAppleMailMCP/Server.swift
@@ -680,7 +680,7 @@ class CheAppleMailMCPServer {
 
         await server.withMethodHandler(CallTool.self) { [weak self] params in
             guard let self = self else {
-                return CallTool.Result(content: [.text("Server unavailable")], isError: true)
+                return CallTool.Result(content: [.text(text: "Server unavailable", annotations: nil, _meta: nil)], isError: true)
             }
             return await self.handleToolCall(name: params.name, arguments: params.arguments ?? [:])
         }
@@ -691,9 +691,9 @@ class CheAppleMailMCPServer {
     private func handleToolCall(name: String, arguments: [String: Value]) async -> CallTool.Result {
         do {
             let result = try await executeToolCall(name: name, arguments: arguments)
-            return CallTool.Result(content: [.text(result)])
+            return CallTool.Result(content: [.text(text: result, annotations: nil, _meta: nil)])
         } catch {
-            return CallTool.Result(content: [.text("Error: \(error.localizedDescription)")], isError: true)
+            return CallTool.Result(content: [.text(text: "Error: \(error.localizedDescription)", annotations: nil, _meta: nil)], isError: true)
         }
     }
 

--- a/Tests/CheAppleMailMCPTests/MailControllerComposeTests.swift
+++ b/Tests/CheAppleMailMCPTests/MailControllerComposeTests.swift
@@ -98,9 +98,11 @@ final class MailControllerComposeTests: XCTestCase {
             bcc: ["bcc@x.y"],
             format: .plain
         )
-        XCTAssertTrue(script.contains("to recipient"))
-        XCTAssertTrue(script.contains("cc recipient"))
-        XCTAssertTrue(script.contains("bcc recipient"))
+        // #84: recipient fragments MUST live inside `tell newMessage … end tell`
+        // (outside the block Mail.app rejects the script at runtime).
+        assertOrdered(script, "to recipient", between: "tell newMessage", and: "end tell")
+        assertOrdered(script, "cc recipient", between: "tell newMessage", and: "end tell")
+        assertOrdered(script, "bcc recipient", between: "tell newMessage", and: "end tell")
     }
 
     // MARK: - buildCreateDraftScript
@@ -123,9 +125,12 @@ final class MailControllerComposeTests: XCTestCase {
             body: "*italic*",
             format: .markdown
         )
-        XCTAssertTrue(script.contains("save newMessage"))
-        XCTAssertTrue(script.contains("set html content to"))
-        XCTAssertTrue(script.contains("<em>italic</em>"))
+        // #84: `set html content to` MUST live inside `tell newMessage` block;
+        // `save newMessage` is the top-level command and stays as a lenient
+        // boundary-token contains() check.
+        XCTAssertTrue(script.contains("save newMessage"))  // top-level command — boundary token
+        assertOrdered(script, "set html content to", between: "tell newMessage", and: "end tell")
+        assertOrdered(script, "<em>italic</em>", between: "tell newMessage", and: "end tell")
     }
 
     func testBuildCreateDraftScript_htmlMode_embedsRawHTML() throws {
@@ -135,8 +140,13 @@ final class MailControllerComposeTests: XCTestCase {
             body: "<a href=\"https://example.com\">link</a>",
             format: .html
         )
-        XCTAssertTrue(script.contains("set html content to"))
-        XCTAssertTrue(script.contains("href=\\\"https://example.com\\\""))
+        // #84: `set html content to` MUST live inside `tell newMessage`.
+        // The href substring appears TWICE in html mode (once in the
+        // plain `content:` property literal at the top, then again
+        // inside `set html content to`) so first-occurrence ordering
+        // would trip — stays as a lenient contains() check.
+        assertOrdered(script, "set html content to", between: "tell newMessage", and: "end tell")
+        XCTAssertTrue(script.contains("href=\\\"https://example.com\\\""))  // appears in both plain + html — lenient
     }
 
     // MARK: - composeReplyHTML (reply/forward HTML composition)
@@ -272,9 +282,10 @@ final class MailControllerComposeTests: XCTestCase {
             originalHTML: nil,
             originalPlain: "Original line 1\nOriginal line 2"
         )
-        XCTAssertTrue(script.contains("set content to"), "plain mode still uses `set content to`")
-        XCTAssertTrue(script.contains("> Original line 1"), "quoted original line must appear in the script literal")
-        XCTAssertTrue(script.contains("> Original line 2"), "every original line must be quoted")
+        // #84: plain-mode body construction MUST live inside `tell replyMsg`.
+        assertOrdered(script, "set content to", between: "tell replyMsg", and: "end tell")
+        assertOrdered(script, "> Original line 1", between: "tell replyMsg", and: "end tell")
+        assertOrdered(script, "> Original line 2", between: "tell replyMsg", and: "end tell")
         XCTAssertFalse(script.contains("& return & return & content"), "broken AppleScript `& content` pattern MUST be removed (#43)")
         XCTAssertFalse(script.contains("html content"), "plain mode MUST NOT touch html content")
         XCTAssertFalse(script.contains("<blockquote>"), "plain mode MUST NOT wrap in blockquote (HTML tag)")
@@ -291,8 +302,9 @@ final class MailControllerComposeTests: XCTestCase {
             originalHTML: nil,
             originalPlain: ""
         )
-        XCTAssertTrue(script.contains("set content to"), "plain mode still uses `set content to`")
-        XCTAssertTrue(script.contains("Reply body"), "user body must appear")
+        // #84: even with empty original, content-set MUST stay inside `tell replyMsg`.
+        assertOrdered(script, "set content to", between: "tell replyMsg", and: "end tell")
+        assertOrdered(script, "Reply body", between: "tell replyMsg", and: "end tell")
         XCTAssertFalse(script.contains("> "), "empty originalPlain MUST NOT emit `> ` quote prefix")
         XCTAssertFalse(script.contains("& return & return & content"), "broken AppleScript `& content` pattern MUST be removed (#43)")
     }
@@ -306,9 +318,11 @@ final class MailControllerComposeTests: XCTestCase {
             originalHTML: "<p>Can you review?</p>",
             originalPlain: "Can you review?"
         )
-        XCTAssertTrue(script.contains("set html content to"))
-        XCTAssertTrue(script.contains("<blockquote>"), "non-plain reply script MUST contain <blockquote>")
-        XCTAssertTrue(script.contains("Thanks, noted."))
+        // #84: markdown reply payload (html content + blockquote + user body)
+        // MUST live inside `tell replyMsg` block.
+        assertOrdered(script, "set html content to", between: "tell replyMsg", and: "end tell")
+        assertOrdered(script, "<blockquote>", between: "tell replyMsg", and: "end tell")
+        assertOrdered(script, "Thanks, noted.", between: "tell replyMsg", and: "end tell")
     }
 
     func testBuildReplyEmailScript_replyAll_usesReplyAllVerb() throws {
@@ -335,9 +349,10 @@ final class MailControllerComposeTests: XCTestCase {
             originalHTML: nil,
             originalPlain: ""
         )
-        XCTAssertTrue(script.contains("make new cc recipient"), "cc_additional MUST emit AppleScript cc recipient fragments")
-        XCTAssertTrue(script.contains("a@b.com"))
-        XCTAssertTrue(script.contains("c@d.com"))
+        // #84: cc recipient fragments MUST be inside `tell replyMsg`.
+        assertOrdered(script, "make new cc recipient", between: "tell replyMsg", and: "end tell")
+        assertOrdered(script, "a@b.com", between: "tell replyMsg", and: "end tell")
+        assertOrdered(script, "c@d.com", between: "tell replyMsg", and: "end tell")
     }
 
     func testBuildReplyEmailScript_attachments_emitsAttachmentFragment() throws {
@@ -350,9 +365,10 @@ final class MailControllerComposeTests: XCTestCase {
             originalHTML: nil,
             originalPlain: ""
         )
-        XCTAssertTrue(script.contains("make new attachment"), "attachments MUST emit AppleScript attachment fragment")
-        XCTAssertTrue(script.contains("POSIX file \"/tmp/cv.pdf\""))
-        XCTAssertTrue(script.contains("POSIX file \"/tmp/cert.pdf\""))
+        // #84: attachment fragments MUST live inside `tell replyMsg`.
+        assertOrdered(script, "make new attachment", between: "tell replyMsg", and: "end tell")
+        assertOrdered(script, "POSIX file \"/tmp/cv.pdf\"", between: "tell replyMsg", and: "end tell")
+        assertOrdered(script, "POSIX file \"/tmp/cert.pdf\"", between: "tell replyMsg", and: "end tell")
     }
 
     func testBuildReplyEmailScript_saveAsDraft_replacesSendWithSave() throws {
@@ -399,10 +415,13 @@ final class MailControllerComposeTests: XCTestCase {
             originalHTML: "<p>Can you review?</p>",
             originalPlain: "Can you review?"
         )
-        XCTAssertTrue(script.contains("set html content to"), "html branch should still set html content")
-        XCTAssertTrue(script.contains("make new cc recipient"), "html branch must also support cc_additional")
-        XCTAssertTrue(script.contains("make new attachment"), "html branch must also support attachments")
-        XCTAssertTrue(script.contains("save replyMsg"), "html branch must also support save_as_draft")
+        // #84: html branch payload + cc + attachment MUST live inside `tell replyMsg`.
+        // `save replyMsg` is the top-level dispatch verb (outside the block) and
+        // stays as a lenient boundary-token contains() check.
+        assertOrdered(script, "set html content to", between: "tell replyMsg", and: "end tell")
+        assertOrdered(script, "make new cc recipient", between: "tell replyMsg", and: "end tell")
+        assertOrdered(script, "make new attachment", between: "tell replyMsg", and: "end tell")
+        XCTAssertTrue(script.contains("save replyMsg"), "html branch must also support save_as_draft")  // top-level command — boundary token
         XCTAssertFalse(script.contains("send replyMsg"))
     }
 
@@ -468,11 +487,14 @@ final class MailControllerComposeTests: XCTestCase {
             originalHTML: nil,
             originalPlain: "Original line 1\nOriginal line 2"
         )
-        XCTAssertTrue(script.contains("forward originalMsg"))
-        XCTAssertTrue(script.contains("to recipient"))
-        XCTAssertTrue(script.contains("set content to"))
-        XCTAssertTrue(script.contains("> Original line 1"), "quoted original must appear in script")
-        XCTAssertTrue(script.contains("> Original line 2"), "every original line must be quoted")
+        // #84: `forward originalMsg` is a top-level command (boundary token);
+        // `set content to` and the quoted lines MUST live inside `tell fwdMsg`;
+        // `to recipient` (forward target) also inside `tell fwdMsg`.
+        XCTAssertTrue(script.contains("forward originalMsg"))  // top-level command — boundary token
+        assertOrdered(script, "to recipient", between: "tell fwdMsg", and: "end tell")
+        assertOrdered(script, "set content to", between: "tell fwdMsg", and: "end tell")
+        assertOrdered(script, "> Original line 1", between: "tell fwdMsg", and: "end tell")
+        assertOrdered(script, "> Original line 2", between: "tell fwdMsg", and: "end tell")
         XCTAssertFalse(script.contains("& return & return & content"), "broken `& content` AppleScript pattern MUST be removed (#44)")
         XCTAssertFalse(script.contains("html content"), "plain mode MUST NOT touch html content")
     }
@@ -490,8 +512,9 @@ final class MailControllerComposeTests: XCTestCase {
             originalHTML: nil,
             originalPlain: ""
         )
-        XCTAssertTrue(script.contains("set content to"))
-        XCTAssertTrue(script.contains("FYI"))
+        // #84: empty-original forward still has user body content inside `tell fwdMsg`.
+        assertOrdered(script, "set content to", between: "tell fwdMsg", and: "end tell")
+        assertOrdered(script, "FYI", between: "tell fwdMsg", and: "end tell")
         XCTAssertFalse(script.contains("> "), "empty originalPlain MUST NOT emit `> ` quote prefix")
         XCTAssertFalse(script.contains("html content"))
     }
@@ -505,8 +528,10 @@ final class MailControllerComposeTests: XCTestCase {
             originalHTML: "<p>Original</p>",
             originalPlain: "Original"
         )
-        XCTAssertTrue(script.contains("set html content to"))
-        XCTAssertTrue(script.contains("<blockquote>"))
+        // #84: html-mode forward payload (html content + blockquote) MUST live
+        // inside `tell fwdMsg` block.
+        assertOrdered(script, "set html content to", between: "tell fwdMsg", and: "end tell")
+        assertOrdered(script, "<blockquote>", between: "tell fwdMsg", and: "end tell")
     }
 
     func testBuildForwardEmailScript_noBody_omitsContentMutation() throws {


### PR DESCRIPTION
Refs #82 #83 #84

## Summary

Cluster-PR addressing 3 chore sister bugs from cluster A's Step 5.7 sweep. Each commit has `Refs #N` for traceability; reviewer can read commits independently or treat as one themed batch (warning cleanup + API migration + test tightening).

| Commit | Issue | Highlight |
|---|---|---|
| `6ad13b2` | #82 | Remove 4 dead `let script = ...` AppleScript declarations in `MailController.swift` (each shadowed by `*Script` variable, never executed). Warning count drops by 4. |
| `c1899d0` | #83 | Migrate 3 deprecated `text(_:metadata:)` calls in `Server.swift` to canonical `.text(text:annotations:_meta:)` enum case. Deprecation-warning count drops by 3. |
| `48eda81` | #84 | Retrofit 31 of 57 lenient `XCTAssertTrue(script.contains(...))` to `assertOrdered(...)`. Pins property-in-tell-block invariants; remaining 24 stay lenient with documented rationale. |
| `2e1d15d` | — | CHANGELOG `[Unreleased]` entry covering the cluster. |

## Test status

`swift test` → **321/0/8** (unchanged from v2.8.2 baseline). All pure cleanup; production behavior unaffected.

`swift build` warning count: cleared 4 `script never used` + 3 `text(_:metadata:) is deprecated` warnings.

## Verification commands

```bash
# #82 — no dead script vars left
grep -c "warning.*'script' was never used" /tmp/build.log  # → 0

# #83 — no deprecated text() calls left
grep -c "text(_:metadata:) is deprecated.*Server.swift" /tmp/build.log  # → 0

# #84 — retrofit progress (33 assertOrdered total = 2 from cluster A + 31 this PR; 24 stay lenient)
grep -c "assertOrdered(script" Tests/CheAppleMailMCPTests/MailControllerComposeTests.swift  # → 33
grep -c "XCTAssertTrue(script.contains" Tests/CheAppleMailMCPTests/MailControllerComposeTests.swift  # → 24
```

## Behavior change

**None**. Items are: dead-code removal (#82), deprecated-factory rename (#83), test-assertion tightening (#84). No runtime path changes.

---
Per IDD discipline: `/idd-close` per issue runs after merge to gate checklists + post per-issue closing summaries. No auto-close trailers (this PR description deliberately avoids the magic substring).
