### PR TITLE
refactor(EnvelopeIndexReader): cache reverse-lookup + accountUUIDs primitive (#106)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **`EnvelopeIndexReader` extracts 4 duplicated O(n) reverse-lookups behind cached `accountUUIDs(forName:) -> [String]` primitive** ([#106](https://github.com/PsychQuant/che-apple-mail-mcp/issues/106)). Pre-refactor, `accountMap.first(where: { $0.value == accountName })?.key` appeared in 4 callsites (`listMailboxes`, `listEmails`, `getUnreadCount`, `searchEmails`) — each O(n) over `accountMap.count`, each silently picking ONE UUID non-deterministically when 2+ accounts share a display_name (the latent ambiguity surfaced by [#101](https://github.com/PsychQuant/che-apple-mail-mcp/issues/101)). Post-refactor: a private `reverseAccountMap: [String: [String]]` is built in `init` (and rebuilt in `updateAccountMapping`, regression-locked against lazy-var staleness); the new public `accountUUIDs(forName name: String) -> [String]` returns `[]` for unknown / `[UUID]` for unambiguous / `[UUID-A, UUID-B]` for collision — callers detect collision via `.count > 1`. Zero behavior change for existing callsites (`.first` of the array reproduces the previous non-deterministic single-UUID pick), but sets up the collision-aware path for the upcoming `#101` `account_id` fix without duplicating the primitive across 5 places. 4 new tests cover unambiguous / collision / unknown / `updateAccountMapping`-rebuild. `grep 'accountMap.first(where:' Sources/MailSQLite/EnvelopeIndexReader.swift` now returns 0 hits.
+
 ## [2.8.5] - 2026-05-11
 
 ### Added

--- a/Sources/MailSQLite/EnvelopeIndexReader.swift
+++ b/Sources/MailSQLite/EnvelopeIndexReader.swift
@@ -65,6 +65,11 @@ public final class EnvelopeIndexReader {
     /// Mapping from account UUID to human-readable account name.
     private var accountMap: [String: String]
 
+    /// Reverse index: display_name → list of UUIDs. Rebuilt whenever
+    /// `accountMap` is set. List form (not single value) surfaces
+    /// multi-account-same-display-name collisions to callers — see #101.
+    private var reverseAccountMap: [String: [String]]
+
     // MARK: - Initialization
 
     /// Open the Envelope Index database in read-only mode.
@@ -76,7 +81,9 @@ public final class EnvelopeIndexReader {
     /// - Throws: `MailSQLiteError.databaseNotAccessible` if the file
     ///   does not exist or cannot be opened (e.g., missing Full Disk Access).
     public init(databasePath: String, accountMapping: [String: String]? = nil) throws {
-        self.accountMap = accountMapping ?? AccountMapper.buildMapping()
+        let mapping = accountMapping ?? AccountMapper.buildMapping()
+        self.accountMap = mapping
+        self.reverseAccountMap = Self.buildReverseMap(from: mapping)
 
         guard FileManager.default.fileExists(atPath: databasePath) else {
             throw MailSQLiteError.databaseNotAccessible(
@@ -117,6 +124,31 @@ public final class EnvelopeIndexReader {
     /// Update the account mapping (e.g., after querying AppleScript).
     public func updateAccountMapping(_ mapping: [String: String]) {
         accountMap = mapping
+        reverseAccountMap = Self.buildReverseMap(from: mapping)
+    }
+
+    /// Reverse lookup: display name → list of UUIDs that map to it.
+    ///
+    /// Returns an empty array for unknown names. When 2+ UUIDs share the
+    /// same display name (e.g., iCloud catch-all alias + Gmail with the
+    /// same address), all are returned — callers can detect collision via
+    /// `.count > 1` and decide whether to surface a disambiguation hint.
+    ///
+    /// Backs the 4 previously-duplicated O(n) reverse-lookup callsites
+    /// inside this file. Externally, sets up the collision-aware path for
+    /// the `#101` `account_id` fix.
+    public func accountUUIDs(forName name: String) -> [String] {
+        reverseAccountMap[name] ?? []
+    }
+
+    /// Build the reverse index in O(n). Called from `init` and
+    /// `updateAccountMapping` to keep the index in sync with `accountMap`.
+    private static func buildReverseMap(from mapping: [String: String]) -> [String: [String]] {
+        var rev: [String: [String]] = [:]
+        for (uuid, name) in mapping {
+            rev[name, default: []].append(uuid)
+        }
+        return rev
     }
 
     /// Build account mapping by scanning the mail storage directory

--- a/Sources/MailSQLite/EnvelopeIndexReader.swift
+++ b/Sources/MailSQLite/EnvelopeIndexReader.swift
@@ -213,7 +213,7 @@ public final class EnvelopeIndexReader {
         var bindings: [String] = []
 
         if let accountName = accountName {
-            if let uuid = accountMap.first(where: { $0.value == accountName })?.key {
+            if let uuid = accountUUIDs(forName: accountName).first {
                 sql += " WHERE url LIKE ?"
                 bindings.append("%://\(uuid)/%")
             }
@@ -256,7 +256,7 @@ public final class EnvelopeIndexReader {
         var bindings: [String] = []
 
         // Account filter
-        if let uuid = accountMap.first(where: { $0.value == accountName })?.key {
+        if let uuid = accountUUIDs(forName: accountName).first {
             conditions.append("mb.url LIKE ?")
             bindings.append("%://\(uuid)/%")
         }
@@ -315,7 +315,7 @@ public final class EnvelopeIndexReader {
         var conditions: [String] = []
         var bindings: [String] = []
 
-        if let accountName = accountName, let uuid = accountMap.first(where: { $0.value == accountName })?.key {
+        if let accountName = accountName, let uuid = accountUUIDs(forName: accountName).first {
             conditions.append("url LIKE ?")
             bindings.append("%://\(uuid)/%")
         }
@@ -505,8 +505,7 @@ public final class EnvelopeIndexReader {
 
         // Account filter via mailbox URL
         if let accountName = params.accountName {
-            // Find UUID for account name (reverse lookup)
-            if let uuid = accountMap.first(where: { $0.value == accountName })?.key {
+            if let uuid = accountUUIDs(forName: accountName).first {
                 conditions.append("mb.url LIKE ?")
                 bindings.append("%://\(uuid)/%")
             }

--- a/Tests/MailSQLiteTests/EnvelopeIndexReaderTests.swift
+++ b/Tests/MailSQLiteTests/EnvelopeIndexReaderTests.swift
@@ -1,7 +1,44 @@
 import XCTest
+import SQLite3
 @testable import MailSQLite
 
 final class EnvelopeIndexReaderTests: XCTestCase {
+
+    // MARK: - Hermetic Test Fixture (#106 verify follow-up)
+
+    /// Create an empty SQLite file in a temp directory + register cleanup.
+    /// Returns the path, which is suitable for `EnvelopeIndexReader(databasePath:)`
+    /// init (read-only open succeeds on any valid SQLite file, including empty).
+    ///
+    /// Lets the reverse-lookup tests run hermetically — independent of whether
+    /// the host machine has a real Apple Mail Envelope Index. The reader's
+    /// init only needs the file to be a parseable SQLite database; downstream
+    /// queries are never run (we only test the in-memory accountMap /
+    /// reverseAccountMap pair).
+    private func makeEmptyTestDB() throws -> String {
+        let fm = FileManager.default
+        let tmpDir = fm.temporaryDirectory.appendingPathComponent(
+            "EnvelopeIndexReaderTests-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try fm.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        addTeardownBlock {
+            try? fm.removeItem(at: tmpDir)
+        }
+
+        let dbPath = tmpDir.appendingPathComponent("Envelope Index").path
+        var db: OpaquePointer?
+        let flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_NOMUTEX
+        guard sqlite3_open_v2(dbPath, &db, flags, nil) == SQLITE_OK else {
+            throw NSError(
+                domain: "EnvelopeIndexReaderTests",
+                code: Int(SQLITE_ERROR),
+                userInfo: [NSLocalizedDescriptionKey: "Failed to create empty test SQLite file at \(dbPath)"]
+            )
+        }
+        sqlite3_close(db)
+        return dbPath
+    }
 
     // MARK: - Connection Management
 
@@ -68,57 +105,52 @@ final class EnvelopeIndexReaderTests: XCTestCase {
     }
 
     // MARK: - Account UUID Reverse Lookup (#106)
+    //
+    // Tests use a hermetic temp SQLite fixture (see `makeEmptyTestDB`)
+    // instead of `EnvelopeIndexReader.defaultDatabasePath` + `XCTSkip` —
+    // so CI environments without real Apple Mail data still run the verification.
+    // Addresses Codex P3 follow-up from /idd-verify --pr 108 review.
 
     func testAccountUUIDs_unambiguous_returnsSingleUUID() throws {
-        let path = EnvelopeIndexReader.defaultDatabasePath
-        guard FileManager.default.fileExists(atPath: path) else {
-            throw XCTSkip("Envelope Index not available")
-        }
         let reader = try EnvelopeIndexReader(
-            databasePath: path,
+            databasePath: try makeEmptyTestDB(),
             accountMapping: ["UUID-A": "Alice"]
         )
         XCTAssertEqual(reader.accountUUIDs(forName: "Alice"), ["UUID-A"])
     }
 
     func testAccountUUIDs_collision_returnsAllUUIDs() throws {
-        let path = EnvelopeIndexReader.defaultDatabasePath
-        guard FileManager.default.fileExists(atPath: path) else {
-            throw XCTSkip("Envelope Index not available")
-        }
         let reader = try EnvelopeIndexReader(
-            databasePath: path,
+            databasePath: try makeEmptyTestDB(),
             accountMapping: [
                 "UUID-A": "Same",
                 "UUID-B": "Same",
                 "UUID-C": "Other"
             ]
         )
-        let collisionUUIDs = Set(reader.accountUUIDs(forName: "Same"))
-        XCTAssertEqual(collisionUUIDs, Set(["UUID-A", "UUID-B"]),
+        let collisionList = reader.accountUUIDs(forName: "Same")
+        // Count assertion first — catches duplicate-UUID regression that the
+        // downstream Set comparison would silently swallow (Devil's Advocate
+        // P3 finding from /idd-verify --pr 108: if impl ever returned
+        // [UUID-A, UUID-A, UUID-B] the Set check would still pass).
+        XCTAssertEqual(collisionList.count, 2,
+                       "Collision result must contain exactly 2 UUIDs — no duplicates")
+        XCTAssertEqual(Set(collisionList), Set(["UUID-A", "UUID-B"]),
                        "Collision case must surface BOTH UUIDs (callers detect via .count > 1)")
         XCTAssertEqual(reader.accountUUIDs(forName: "Other"), ["UUID-C"])
     }
 
     func testAccountUUIDs_unknown_returnsEmpty() throws {
-        let path = EnvelopeIndexReader.defaultDatabasePath
-        guard FileManager.default.fileExists(atPath: path) else {
-            throw XCTSkip("Envelope Index not available")
-        }
         let reader = try EnvelopeIndexReader(
-            databasePath: path,
+            databasePath: try makeEmptyTestDB(),
             accountMapping: ["UUID-A": "Alice"]
         )
         XCTAssertEqual(reader.accountUUIDs(forName: "Nobody"), [])
     }
 
     func testAccountUUIDs_reflectsUpdateAccountMapping() throws {
-        let path = EnvelopeIndexReader.defaultDatabasePath
-        guard FileManager.default.fileExists(atPath: path) else {
-            throw XCTSkip("Envelope Index not available")
-        }
         let reader = try EnvelopeIndexReader(
-            databasePath: path,
+            databasePath: try makeEmptyTestDB(),
             accountMapping: ["UUID-A": "Alice"]
         )
         XCTAssertEqual(reader.accountUUIDs(forName: "Alice"), ["UUID-A"])

--- a/Tests/MailSQLiteTests/EnvelopeIndexReaderTests.swift
+++ b/Tests/MailSQLiteTests/EnvelopeIndexReaderTests.swift
@@ -66,4 +66,69 @@ final class EnvelopeIndexReaderTests: XCTestCase {
             XCTAssertEqual(uuid.count, 36, "UUID should be 36 chars: \(uuid)")
         }
     }
+
+    // MARK: - Account UUID Reverse Lookup (#106)
+
+    func testAccountUUIDs_unambiguous_returnsSingleUUID() throws {
+        let path = EnvelopeIndexReader.defaultDatabasePath
+        guard FileManager.default.fileExists(atPath: path) else {
+            throw XCTSkip("Envelope Index not available")
+        }
+        let reader = try EnvelopeIndexReader(
+            databasePath: path,
+            accountMapping: ["UUID-A": "Alice"]
+        )
+        XCTAssertEqual(reader.accountUUIDs(forName: "Alice"), ["UUID-A"])
+    }
+
+    func testAccountUUIDs_collision_returnsAllUUIDs() throws {
+        let path = EnvelopeIndexReader.defaultDatabasePath
+        guard FileManager.default.fileExists(atPath: path) else {
+            throw XCTSkip("Envelope Index not available")
+        }
+        let reader = try EnvelopeIndexReader(
+            databasePath: path,
+            accountMapping: [
+                "UUID-A": "Same",
+                "UUID-B": "Same",
+                "UUID-C": "Other"
+            ]
+        )
+        let collisionUUIDs = Set(reader.accountUUIDs(forName: "Same"))
+        XCTAssertEqual(collisionUUIDs, Set(["UUID-A", "UUID-B"]),
+                       "Collision case must surface BOTH UUIDs (callers detect via .count > 1)")
+        XCTAssertEqual(reader.accountUUIDs(forName: "Other"), ["UUID-C"])
+    }
+
+    func testAccountUUIDs_unknown_returnsEmpty() throws {
+        let path = EnvelopeIndexReader.defaultDatabasePath
+        guard FileManager.default.fileExists(atPath: path) else {
+            throw XCTSkip("Envelope Index not available")
+        }
+        let reader = try EnvelopeIndexReader(
+            databasePath: path,
+            accountMapping: ["UUID-A": "Alice"]
+        )
+        XCTAssertEqual(reader.accountUUIDs(forName: "Nobody"), [])
+    }
+
+    func testAccountUUIDs_reflectsUpdateAccountMapping() throws {
+        let path = EnvelopeIndexReader.defaultDatabasePath
+        guard FileManager.default.fileExists(atPath: path) else {
+            throw XCTSkip("Envelope Index not available")
+        }
+        let reader = try EnvelopeIndexReader(
+            databasePath: path,
+            accountMapping: ["UUID-A": "Alice"]
+        )
+        XCTAssertEqual(reader.accountUUIDs(forName: "Alice"), ["UUID-A"])
+        XCTAssertEqual(reader.accountUUIDs(forName: "Bob"), [])
+
+        // Replace mapping — reverse map MUST rebuild, not stay stale.
+        // Regression-locks the "lazy var staleness" bug pattern flagged in #106 body.
+        reader.updateAccountMapping(["UUID-Z": "Bob"])
+        XCTAssertEqual(reader.accountUUIDs(forName: "Alice"), [],
+                       "After updateAccountMapping, old name 'Alice' must not resolve to any UUID")
+        XCTAssertEqual(reader.accountUUIDs(forName: "Bob"), ["UUID-Z"])
+    }
 }


### PR DESCRIPTION
Refs #106

## Summary

Pure refactor + 1 new public primitive (`accountUUIDs(forName:) -> [String]`) backing a cached reverse-map. Zero behavior change for existing callers; deduplicates 4 O(n) reverse lookups in `EnvelopeIndexReader.swift`.

**Why now**: surfaced during `/idd-plan #101` Step 2.5 tangential sweep. Sets up the collision-aware primitive that `#101`'s `account_id` fix will need — landing this first means `#101` Phase 1 reuses the primitive instead of adding a 5th duplication.

## Behavior

- `accountUUIDs(forName:)` returns `[]` for unknown / `[UUID]` for unambiguous / `[UUID-A, UUID-B]` for collision
- Callers detect collision via `.count > 1`
- Existing 4 callsites use `.first` to preserve **exact previous behavior** (non-deterministic single-UUID pick on collision is preserved as-is — this PR exposes the latent ambiguity through a typed primitive but does not change runtime behavior)
- `reverseAccountMap` rebuilt in `init` AND `updateAccountMapping` — no lazy-var staleness path

## Commits

- `0d11126` test: 4 RED tests for `accountUUIDs(forName:)` primitive
- `b855eef` feat: cached `reverseAccountMap` + `accountUUIDs(forName:)` + `buildReverseMap` helper
- `837393a` refactor: replace 4 O(n) reverse lookups with `accountUUIDs(forName:).first`
- `f0a155c` docs(changelog): `[Unreleased] ### Changed` entry

## Verification

- `swift test` — 346/346 pass (8 env-skipped), 4 new tests added
- `grep 'accountMap.first(where:' Sources/MailSQLite/EnvelopeIndexReader.swift` — 0 hits (was 4)
- 65 lines test added / 43 lines source touched / 3 lines changelog

## Checklist

- [x] Diagnose (self-diagnostic issue body, Simple complexity)
- [x] Implement (4 commits)
- [ ] Verify (run `/idd-verify #106`)
- [ ] **Pending: human review of this PR + `/idd-close #106` after merge**

## Related

- **#101** — depends on `accountUUIDs(forName:)` primitive landing first to avoid duplication in Phase 1
- **#104** — `~14 tools sweep` will reuse the same primitive for its disambiguation logic

---
Generated by `/idd-implement` on PR path. **Do NOT add 'Closes #106'** — IDD discipline requires manual `/idd-close` after merge to enforce checklist gate + closing summary.
