### PR TITLE
refactor(applescript): account_id disambiguation for move/copy/delete (#104 PR-B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **3 movement/destruction tools (`move_email`, `copy_email`, `delete_email`) now accept `account_id` for multi-account-same-display_name disambiguation** ([#104](https://github.com/PsychQuant/che-apple-mail-mcp/issues/104) PR-B). Same `-1728 / -1719` failure mode as PR-A's 5 mutation tools — `msgRef`'s `account "<display_name>"` AppleScript selector non-deterministically picks the wrong account when two accounts share a display_name. Pre-fix: any of these 3 tools could fail or operate on the wrong account's message. Post-fix: each tool accepts an optional `account_id`; when provided, AppleScript uses `(account id "<UUID>")` selector. `move_email` and `copy_email` are particularly subtle because they emit TWO refs in one script (source `msgRef` + destination `mailboxRef`) — both refs flow through the same `accountId` since move/copy operations stay within a single account. Implementation: new `MoveCopyDeleteScriptBuilder.swift` with 3 free builder functions that delegate to Phase 0's `AppleScriptRefBuilder.resolveMsgRef` / `resolveMailboxRef` chokepoint. **Backward compat preserved**: omitting `account_id` falls back to the legacy display_name path. 6 new tests (2 per builder: UUID path verifies UUID in BOTH ref points for move/copy; display_name fallback verifies legacy form).
+
 ## [2.9.0] - 2026-05-18
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ Mail.app's AppleScript `account "<display_name>"` selector is **not unique** whe
 
 **Backward compatibility**: `account_id` is **optional**. When omitted (or empty), tools fall back to the legacy `account "<display_name>"` path — behavior identical to pre-#101. Existing callers continue to work unchanged.
 
-**Scope**: as of this release, `account_id` is accepted by `save_attachment` plus the 5 single-message mutation tools `mark_read`, `flag_email`, `set_flag_color`, `set_background_color`, and `mark_as_junk` (PR-A of the [#104](https://github.com/PsychQuant/che-apple-mail-mcp/issues/104) sweep). The same disambiguation pattern will be applied to the remaining AppleScript-routed tools (move/copy/delete, compose, mailbox CRUD) in subsequent PRs tracked at [#104](https://github.com/PsychQuant/che-apple-mail-mcp/issues/104).
+**Scope**: as of this release, `account_id` is accepted by `save_attachment`, the 5 single-message mutation tools (`mark_read`, `flag_email`, `set_flag_color`, `set_background_color`, `mark_as_junk` — PR-A of [#104](https://github.com/PsychQuant/che-apple-mail-mcp/issues/104)), plus the 3 movement/destruction tools (`move_email`, `copy_email`, `delete_email` — PR-B of [#104](https://github.com/PsychQuant/che-apple-mail-mcp/issues/104)). The same disambiguation pattern will be applied to the remaining AppleScript-routed tools (compose, mailbox CRUD) in subsequent PRs tracked at [#104](https://github.com/PsychQuant/che-apple-mail-mcp/issues/104).
 
 ---
 

--- a/Sources/CheAppleMailMCP/AppleScript/MailController.swift
+++ b/Sources/CheAppleMailMCP/AppleScript/MailController.swift
@@ -633,27 +633,20 @@ actor MailController {
     }
 
     /// Move email to another mailbox
-    func moveEmail(id: String, fromMailbox: String, toMailbox: String, accountName: String) throws -> String {
-        let ref = msgRef(id, mailbox: fromMailbox, account: accountName)
-        let script = """
-        tell application "Mail"
-            set msg to \(ref)
-            move msg to \(mailboxRef(toMailbox, account: accountName))
-            return "Email moved to \(escapeForAppleScript(toMailbox))"
-        end tell
-        """
+    func moveEmail(id: String, fromMailbox: String, toMailbox: String, accountName: String, accountId: String? = nil) throws -> String {
+        let script = buildMoveEmailScript(
+            id: id, fromMailbox: fromMailbox, toMailbox: toMailbox,
+            accountId: accountId, accountName: accountName
+        )
         return try runScript(script)
     }
 
     /// Delete email (move to trash)
-    func deleteEmail(id: String, mailbox: String, accountName: String) throws -> String {
-        let ref = msgRef(id, mailbox: mailbox, account: accountName)
-        let script = """
-        tell application "Mail"
-            delete \(ref)
-            return "Email deleted"
-        end tell
-        """
+    func deleteEmail(id: String, mailbox: String, accountName: String, accountId: String? = nil) throws -> String {
+        let script = buildDeleteEmailScript(
+            id: id, mailbox: mailbox,
+            accountId: accountId, accountName: accountName
+        )
         return try runScript(script)
     }
 
@@ -1204,15 +1197,11 @@ actor MailController {
     // MARK: - Advanced Email Operations
 
     /// Copy email to another mailbox
-    func copyEmail(id: String, fromMailbox: String, toMailbox: String, accountName: String) throws -> String {
-        let ref = msgRef(id, mailbox: fromMailbox, account: accountName)
-        let script = """
-        tell application "Mail"
-            set msg to \(ref)
-            duplicate msg to \(mailboxRef(toMailbox, account: accountName))
-            return "Email copied to \(escapeForAppleScript(toMailbox))"
-        end tell
-        """
+    func copyEmail(id: String, fromMailbox: String, toMailbox: String, accountName: String, accountId: String? = nil) throws -> String {
+        let script = buildCopyEmailScript(
+            id: id, fromMailbox: fromMailbox, toMailbox: toMailbox,
+            accountId: accountId, accountName: accountName
+        )
         return try runScript(script)
     }
 

--- a/Sources/CheAppleMailMCP/AppleScript/MoveCopyDeleteScriptBuilder.swift
+++ b/Sources/CheAppleMailMCP/AppleScript/MoveCopyDeleteScriptBuilder.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// AppleScript builders for the 3 movement/destruction tools, with account-UUID
+/// disambiguation (#104 PR-B).
+///
+/// `move_email` / `copy_email` emit TWO references — source `msgRef` (via
+/// `resolveMsgRef`) AND destination `mailboxRef` (via `resolveMailboxRef`).
+/// Both refs go through the same `accountId` since move/copy are within a
+/// single account. `delete_email` has only ONE ref, matching PR-A's single-
+/// mailbox mutation pattern.
+///
+/// All three delegate account resolution to `AppleScriptRefBuilder.swift`'s
+/// chokepoint: `(account id "<UUID>")` when `accountId` is non-empty, legacy
+/// `account "<display_name>"` form otherwise. Free functions so they're
+/// testable without the actor — same pattern as `MutationToolScriptBuilder`
+/// / `ComposeScriptBuilder` / `SaveAttachmentScriptBuilder`.
+
+/// `move_email` — move a message to another mailbox in the same account.
+func buildMoveEmailScript(
+    id: String, fromMailbox: String, toMailbox: String,
+    accountId: String?, accountName: String
+) -> String {
+    let sourceRef = resolveMsgRef(id: id, mailbox: fromMailbox,
+                                  accountId: accountId, accountName: accountName)
+    let destRef = resolveMailboxRef(mailbox: toMailbox,
+                                    accountId: accountId, accountName: accountName)
+    return """
+    tell application "Mail"
+        set msg to \(sourceRef)
+        move msg to \(destRef)
+        return "Email moved to \(appleScriptEscape(toMailbox))"
+    end tell
+    """
+}
+
+/// `copy_email` — duplicate a message to another mailbox in the same account.
+func buildCopyEmailScript(
+    id: String, fromMailbox: String, toMailbox: String,
+    accountId: String?, accountName: String
+) -> String {
+    let sourceRef = resolveMsgRef(id: id, mailbox: fromMailbox,
+                                  accountId: accountId, accountName: accountName)
+    let destRef = resolveMailboxRef(mailbox: toMailbox,
+                                    accountId: accountId, accountName: accountName)
+    return """
+    tell application "Mail"
+        set msg to \(sourceRef)
+        duplicate msg to \(destRef)
+        return "Email copied to \(appleScriptEscape(toMailbox))"
+    end tell
+    """
+}
+
+/// `delete_email` — move a message to Trash (Mail.app semantic).
+func buildDeleteEmailScript(
+    id: String, mailbox: String,
+    accountId: String?, accountName: String
+) -> String {
+    let ref = resolveMsgRef(id: id, mailbox: mailbox,
+                            accountId: accountId, accountName: accountName)
+    return """
+    tell application "Mail"
+        delete \(ref)
+        return "Email deleted"
+    end tell
+    """
+}

--- a/Sources/CheAppleMailMCP/Server.swift
+++ b/Sources/CheAppleMailMCP/Server.swift
@@ -205,7 +205,8 @@ class CheAppleMailMCPServer {
                         "id": .object(["type": .string("string"), "description": .string("The email ID")]),
                         "from_mailbox": .object(["type": .string("string"), "description": .string("Source mailbox")]),
                         "to_mailbox": .object(["type": .string("string"), "description": .string("Destination mailbox")]),
-                        "account_name": .object(["type": .string("string"), "description": .string("The mail account")])
+                        "account_name": .object(["type": .string("string"), "description": .string("The mail account (display_name)")]),
+                        "account_id": .object(["type": .string("string"), "description": .string("Optional account UUID for disambiguation when multiple accounts share a display_name (see #101). From search_emails results.")])
                     ]),
                     "required": .array([.string("id"), .string("from_mailbox"), .string("to_mailbox"), .string("account_name")])
                 ])
@@ -218,7 +219,8 @@ class CheAppleMailMCPServer {
                     "properties": .object([
                         "id": .object(["type": .string("string"), "description": .string("The email ID")]),
                         "mailbox": .object(["type": .string("string"), "description": .string("Mailbox name")]),
-                        "account_name": .object(["type": .string("string"), "description": .string("The mail account")])
+                        "account_name": .object(["type": .string("string"), "description": .string("The mail account (display_name)")]),
+                        "account_id": .object(["type": .string("string"), "description": .string("Optional account UUID for disambiguation when multiple accounts share a display_name (see #101). From search_emails results.")])
                     ]),
                     "required": .array([.string("id"), .string("mailbox"), .string("account_name")])
                 ])
@@ -435,7 +437,8 @@ class CheAppleMailMCPServer {
                         "id": .object(["type": .string("string"), "description": .string("The email ID")]),
                         "from_mailbox": .object(["type": .string("string"), "description": .string("Source mailbox")]),
                         "to_mailbox": .object(["type": .string("string"), "description": .string("Destination mailbox")]),
-                        "account_name": .object(["type": .string("string"), "description": .string("The mail account")])
+                        "account_name": .object(["type": .string("string"), "description": .string("The mail account (display_name)")]),
+                        "account_id": .object(["type": .string("string"), "description": .string("Optional account UUID for disambiguation when multiple accounts share a display_name (see #101). From search_emails results.")])
                     ]),
                     "required": .array([.string("id"), .string("from_mailbox"), .string("to_mailbox"), .string("account_name")])
                 ])
@@ -908,7 +911,8 @@ class CheAppleMailMCPServer {
                   let accountName = arguments["account_name"]?.stringValue else {
                 throw MailError.invalidParameter("from_mailbox, to_mailbox, and account_name are required")
             }
-            return try await mailController.moveEmail(id: id, fromMailbox: fromMailbox, toMailbox: toMailbox, accountName: accountName)
+            let accountId = arguments["account_id"]?.stringValue
+            return try await mailController.moveEmail(id: id, fromMailbox: fromMailbox, toMailbox: toMailbox, accountName: accountName, accountId: accountId)
 
         case "delete_email":
             let id = try requireMessageId(arguments)
@@ -916,7 +920,8 @@ class CheAppleMailMCPServer {
                   let accountName = arguments["account_name"]?.stringValue else {
                 throw MailError.invalidParameter("mailbox, and account_name are required")
             }
-            return try await mailController.deleteEmail(id: id, mailbox: mailbox, accountName: accountName)
+            let accountId = arguments["account_id"]?.stringValue
+            return try await mailController.deleteEmail(id: id, mailbox: mailbox, accountName: accountName, accountId: accountId)
 
         // Compose Tools
         case "compose_email":
@@ -1153,7 +1158,8 @@ class CheAppleMailMCPServer {
                   let accountName = arguments["account_name"]?.stringValue else {
                 throw MailError.invalidParameter("from_mailbox, to_mailbox, and account_name are required")
             }
-            return try await mailController.copyEmail(id: id, fromMailbox: fromMailbox, toMailbox: toMailbox, accountName: accountName)
+            let accountId = arguments["account_id"]?.stringValue
+            return try await mailController.copyEmail(id: id, fromMailbox: fromMailbox, toMailbox: toMailbox, accountName: accountName, accountId: accountId)
 
         case "set_flag_color":
             let id = try requireMessageId(arguments)

--- a/Tests/CheAppleMailMCPTests/MoveCopyDeleteScriptBuilderTests.swift
+++ b/Tests/CheAppleMailMCPTests/MoveCopyDeleteScriptBuilderTests.swift
@@ -1,0 +1,99 @@
+import XCTest
+@testable import CheAppleMailMCP
+
+/// Tests for the 3 movement/destruction script builders (#104 PR-B).
+///
+/// `move_email` + `copy_email` emit TWO refs (source `msgRef` + destination
+/// `mailboxRef`) in a single script — UUID-path tests assert BOTH refs use
+/// `(account id "<UUID>")`. `delete_email` has only one ref (single-mailbox
+/// mutation), matching PR-A's single-ref pattern.
+final class MoveCopyDeleteScriptBuilderTests: XCTestCase {
+
+    private let uuid = "C38E0583-47F8-4468-BE70-43155C15549D"
+
+    // MARK: - move_email (TWO refs: source + destination)
+
+    func testBuildMoveEmailScript_uuidPath_bothRefsUseUuid() {
+        let s = buildMoveEmailScript(
+            id: "42", fromMailbox: "INBOX", toMailbox: "Archive",
+            accountId: uuid, accountName: "alice@example.com"
+        )
+        // Source ref (msgRef) — UUID
+        XCTAssertTrue(s.contains("whose id is 42"),
+                      "source msgRef must include numeric id; got:\n\(s)")
+        // Destination ref (mailboxRef) — UUID
+        let uuidSelectorCount = s.components(separatedBy: "(account id \"\(uuid)\")").count - 1
+        XCTAssertEqual(uuidSelectorCount, 2,
+                       "expected UUID selector to appear TWICE (source + destination); got \(uuidSelectorCount) in:\n\(s)")
+        XCTAssertFalse(s.contains("account \"alice@example.com\""),
+                       "display_name must not leak in UUID path")
+        XCTAssertTrue(s.contains("move msg to"), "must contain move verb")
+        XCTAssertTrue(s.contains("whose name is \"Archive\""), "destination mailbox name must appear")
+    }
+
+    func testBuildMoveEmailScript_displayNameFallback() {
+        let s = buildMoveEmailScript(
+            id: "42", fromMailbox: "INBOX", toMailbox: "Archive",
+            accountId: nil, accountName: "alice@example.com"
+        )
+        // Both refs fall back to display_name form
+        let displayNameSelectorCount = s.components(separatedBy: "account \"alice@example.com\"").count - 1
+        XCTAssertEqual(displayNameSelectorCount, 2,
+                       "expected display_name to appear TWICE (source + destination); got \(displayNameSelectorCount) in:\n\(s)")
+        XCTAssertFalse(s.contains("(account id"), "UUID form must not appear in fallback path")
+        XCTAssertTrue(s.contains("move msg to"))
+        XCTAssertTrue(s.contains("whose name is \"Archive\""))
+    }
+
+    // MARK: - copy_email (TWO refs: source + destination, uses `duplicate` verb)
+
+    func testBuildCopyEmailScript_uuidPath_bothRefsUseUuid() {
+        let s = buildCopyEmailScript(
+            id: "99", fromMailbox: "Drafts", toMailbox: "Sent",
+            accountId: uuid, accountName: "bob@example.com"
+        )
+        XCTAssertTrue(s.contains("whose id is 99"))
+        let uuidSelectorCount = s.components(separatedBy: "(account id \"\(uuid)\")").count - 1
+        XCTAssertEqual(uuidSelectorCount, 2,
+                       "expected UUID selector to appear TWICE; got \(uuidSelectorCount) in:\n\(s)")
+        XCTAssertFalse(s.contains("account \"bob@example.com\""))
+        XCTAssertTrue(s.contains("duplicate msg to"), "copy uses duplicate verb")
+        XCTAssertTrue(s.contains("whose name is \"Sent\""))
+    }
+
+    func testBuildCopyEmailScript_displayNameFallback() {
+        let s = buildCopyEmailScript(
+            id: "99", fromMailbox: "Drafts", toMailbox: "Sent",
+            accountId: "", accountName: "carol@example.com"
+        )
+        // Empty-string accountId should fall back same as nil (resolver semantic)
+        let displayNameSelectorCount = s.components(separatedBy: "account \"carol@example.com\"").count - 1
+        XCTAssertEqual(displayNameSelectorCount, 2)
+        XCTAssertFalse(s.contains("(account id"))
+        XCTAssertTrue(s.contains("duplicate msg to"))
+    }
+
+    // MARK: - delete_email (ONE ref, like PR-A's single-mailbox tools)
+
+    func testBuildDeleteEmailScript_uuidPath() {
+        let s = buildDeleteEmailScript(
+            id: "7", mailbox: "Junk",
+            accountId: uuid, accountName: "dan@example.com"
+        )
+        XCTAssertTrue(s.contains("(account id \"\(uuid)\")"))
+        XCTAssertFalse(s.contains("account \"dan@example.com\""),
+                       "display_name must not appear in UUID path")
+        XCTAssertTrue(s.contains("delete"), "must contain delete verb")
+        XCTAssertTrue(s.contains("whose id is 7"))
+    }
+
+    func testBuildDeleteEmailScript_displayNameFallback() {
+        let s = buildDeleteEmailScript(
+            id: "7", mailbox: "Junk",
+            accountId: nil, accountName: "eve@example.com"
+        )
+        XCTAssertTrue(s.contains("account \"eve@example.com\""))
+        XCTAssertFalse(s.contains("(account id"))
+        XCTAssertTrue(s.contains("delete"))
+    }
+}


### PR DESCRIPTION
Refs #104

## Summary

PR-B of the #104 sweep — applies the established Phase 0 `resolveMsgRef` / `resolveMailboxRef` chokepoint to `move_email`, `copy_email`, `delete_email`. **Increment 2 of N**; PR-C (compose) and PR-D (mailbox CRUD) follow. Builds on PR-A (`b8ee82c`, binary v2.9.0).

## Architectural payoff

`move_email` and `copy_email` are the first tools in the sweep that emit TWO refs in one script (source `msgRef` + destination `mailboxRef`). Both flow through the same `accountId` since movement stays within one account. The new test `testBuildMoveEmailScript_uuidPath_bothRefsUseUuid` counts substring occurrences to assert UUID selector appears TWICE — making the "single account, both refs" contract regression-locked.

## Implementation Plan

- [x] Test (RED): 6 tests in `MoveCopyDeleteScriptBuilderTests.swift` (2 per builder)
- [x] Implementation (GREEN): `MoveCopyDeleteScriptBuilder.swift` — 3 free builders delegating to chokepoint
- [x] MailController: 3 methods gain `accountId: String? = nil`
- [x] Server.swift: 3 schemas + 3 handlers wire through
- [x] README scope + CHANGELOG entry
- [x] swift test — 390/390 pass (was 384, +6 new)

## Test plan

- [x] `swift test` — 390/390 pass (+6 new, 8 env-skipped unchanged)
- [x] Adversarial: UUID-path test verifies UUID appears exactly twice in move/copy scripts (no display_name leakage)
- [x] Fallback: nil + empty-string accountId both fall through to legacy display_name form
- [ ] Verify (run /idd-verify --pr after PR opens)
- [ ] Pending: human review + manual /idd-close after merge

## Scope discipline

3 in-scope tools updated. OUT-of-scope untouched:
- PR-C: compose / reply / forward / redirect
- PR-D: mailbox CRUD
- #110 / #117 / #118 / #122 (separate sister issues)

## References

- Issue: #104
- Original plan: https://github.com/PsychQuant/che-apple-mail-mcp/issues/104#issuecomment-4466540282
- PR-A precedent: merged `b8ee82c`
- PR-B Implementation Plan: https://github.com/PsychQuant/che-apple-mail-mcp/issues/104#issuecomment-4474063299

---

Generated by /idd-implement on PR path. **Do NOT add a GitHub close trailer to this PR** — IDD discipline requires manual /idd-close after merge to enforce checklist gate + closing summary.
