### PR TITLE
refactor: MailController ↔ builder parameter-order consistency (#117)

### DIFF
--- a/Sources/CheAppleMailMCP/AppleScript/MailController.swift
+++ b/Sources/CheAppleMailMCP/AppleScript/MailController.swift
@@ -619,13 +619,13 @@ actor MailController {
     // MARK: - Email Actions
 
     /// Mark email as read/unread
-    func markRead(id: String, mailbox: String, accountName: String, accountId: String? = nil, read: Bool) throws -> String {
+    func markRead(id: String, mailbox: String, accountId: String? = nil, accountName: String, read: Bool) throws -> String {
         let script = buildMarkReadScript(id: id, mailbox: mailbox, accountId: accountId, accountName: accountName, read: read)
         return try runScript(script)
     }
 
     /// Flag email
-    func flagEmail(id: String, mailbox: String, accountName: String, accountId: String? = nil, flagged: Bool) throws -> String {
+    func flagEmail(id: String, mailbox: String, accountId: String? = nil, accountName: String, flagged: Bool) throws -> String {
         let script = buildFlagEmailScript(id: id, mailbox: mailbox, accountId: accountId, accountName: accountName, flagged: flagged)
         return try runScript(script)
     }
@@ -1169,20 +1169,20 @@ actor MailController {
     }
 
     /// Set flag color (0-6: red, orange, yellow, green, blue, purple, gray; -1 to clear)
-    func setFlagColor(id: String, mailbox: String, accountName: String, accountId: String? = nil, colorIndex: Int) throws -> String {
+    func setFlagColor(id: String, mailbox: String, accountId: String? = nil, accountName: String, colorIndex: Int) throws -> String {
         let script = buildSetFlagColorScript(id: id, mailbox: mailbox, accountId: accountId, accountName: accountName, colorIndex: colorIndex)
         return try runScript(script)
     }
 
     /// Set email background color
-    func setBackgroundColor(id: String, mailbox: String, accountName: String, accountId: String? = nil, color: String) throws -> String {
+    func setBackgroundColor(id: String, mailbox: String, accountId: String? = nil, accountName: String, color: String) throws -> String {
         // Valid colors: blue, gray, green, none, orange, purple, red, yellow
         let script = buildSetBackgroundColorScript(id: id, mailbox: mailbox, accountId: accountId, accountName: accountName, color: color)
         return try runScript(script)
     }
 
     /// Mark email as junk or not junk
-    func markAsJunk(id: String, mailbox: String, accountName: String, accountId: String? = nil, isJunk: Bool) throws -> String {
+    func markAsJunk(id: String, mailbox: String, accountId: String? = nil, accountName: String, isJunk: Bool) throws -> String {
         let script = buildMarkAsJunkScript(id: id, mailbox: mailbox, accountId: accountId, accountName: accountName, isJunk: isJunk)
         return try runScript(script)
     }

--- a/Sources/CheAppleMailMCP/Server.swift
+++ b/Sources/CheAppleMailMCP/Server.swift
@@ -899,7 +899,7 @@ class CheAppleMailMCPServer {
                 throw MailError.invalidParameter("mailbox, account_name, and read are required")
             }
             let accountId = arguments["account_id"]?.stringValue
-            return try await mailController.markRead(id: id, mailbox: mailbox, accountName: accountName, accountId: accountId, read: read)
+            return try await mailController.markRead(id: id, mailbox: mailbox, accountId: accountId, accountName: accountName, read: read)
 
         case "flag_email":
             let id = try requireMessageId(arguments)
@@ -909,7 +909,7 @@ class CheAppleMailMCPServer {
                 throw MailError.invalidParameter("mailbox, account_name, and flagged are required")
             }
             let accountId = arguments["account_id"]?.stringValue
-            return try await mailController.flagEmail(id: id, mailbox: mailbox, accountName: accountName, accountId: accountId, flagged: flagged)
+            return try await mailController.flagEmail(id: id, mailbox: mailbox, accountId: accountId, accountName: accountName, flagged: flagged)
 
         case "move_email":
             let id = try requireMessageId(arguments)
@@ -1190,7 +1190,7 @@ class CheAppleMailMCPServer {
                 throw MailError.invalidParameter("mailbox, account_name, and color_index are required")
             }
             let accountId = arguments["account_id"]?.stringValue
-            return try await mailController.setFlagColor(id: id, mailbox: mailbox, accountName: accountName, accountId: accountId, colorIndex: colorIndex)
+            return try await mailController.setFlagColor(id: id, mailbox: mailbox, accountId: accountId, accountName: accountName, colorIndex: colorIndex)
 
         case "set_background_color":
             let id = try requireMessageId(arguments)
@@ -1204,7 +1204,7 @@ class CheAppleMailMCPServer {
                     "color must be one of: blue, gray, green, none, orange, purple, red, yellow (got: \"\(color)\")")
             }
             let accountId = arguments["account_id"]?.stringValue
-            return try await mailController.setBackgroundColor(id: id, mailbox: mailbox, accountName: accountName, accountId: accountId, color: color)
+            return try await mailController.setBackgroundColor(id: id, mailbox: mailbox, accountId: accountId, accountName: accountName, color: color)
 
         case "mark_as_junk":
             let id = try requireMessageId(arguments)
@@ -1214,7 +1214,7 @@ class CheAppleMailMCPServer {
                 throw MailError.invalidParameter("mailbox, account_name, and is_junk are required")
             }
             let accountId = arguments["account_id"]?.stringValue
-            return try await mailController.markAsJunk(id: id, mailbox: mailbox, accountName: accountName, accountId: accountId, isJunk: isJunk)
+            return try await mailController.markAsJunk(id: id, mailbox: mailbox, accountId: accountId, accountName: accountName, isJunk: isJunk)
 
         case "get_email_headers":
             let id = try requireMessageId(arguments)


### PR DESCRIPTION
Refs #117

## Summary
Reorders `accountId` before `accountName` in 5 `MailController` mutation-tool method signatures (`markRead`, `flagEmail`, `setFlagColor`, `setBackgroundColor`, `markAsJunk`) so they match the `buildXxxScript` / `resolveMsgRef` convention `(id, mailbox, accountId, accountName, …)`. Updates the 5 matching `Server.swift` call sites.

Pure parameter reorder — zero behavior change. Removes the footgun flagged by #114's Devil's Advocate review where call sites listed `accountName:` then `accountId:` against a builder slot ordered the other way.

## Verification
- `swift build -c release` clean
- Full `swift test` — 423 tests, 0 failures, 8 skipped
- No test changes: builder tests already exercise the canonical order.

## Checklist
- [x] Diagnose
- [x] Implement (1 commit)
- [x] Verify — 6/6 reviewers PASS
- [ ] **Pending: human review of this PR + /idd-close after merge**

---
Generated by /idd-all. Do NOT add 'Closes #117' — IDD discipline requires manual /idd-close after merge.
