### PR TITLE
fix: release-safe id guard in resolveMsgRef / msgRefByAccountId (#118)

### DIFF
--- a/Sources/CheAppleMailMCP/AppleScript/AppleScriptRefBuilder.swift
+++ b/Sources/CheAppleMailMCP/AppleScript/AppleScriptRefBuilder.swift
@@ -50,11 +50,17 @@ func mailboxRefByAccountId(_ mailbox: String, accountId: String) -> String {
 ///
 /// - Note: Apple Mail's `id` of a message is a numeric internal identifier
 ///   (not the RFC 822 Message-ID string), so `whose id is <N>` is
-///   interpolated unquoted. `assert` catches non-numeric `id` at debug
-///   time — Server-layer `requireMessageId` is the user-facing contract.
+///   interpolated unquoted. A release-safe numeric guard (#118) rejects
+///   non-numeric `id`; Server-layer `requireMessageId` is the user-facing
+///   contract.
 func msgRefByAccountId(_ id: String, mailbox: String, accountId: String) -> String {
-    assert(Int(id) != nil, "msgRefByAccountId called with non-numeric id '\(id)' — Server.swift handler missed validation (#50)")
-    return "(first message of \(mailboxRefByAccountId(mailbox, accountId: accountId)) whose id is \(id))"
+    // Release-safe guard (#118): `id` is interpolated unquoted into `whose id is`.
+    // A debug-only `assert` compiles out under `-O`, so a caller bypassing
+    // `Server.requireMessageId` could inject an AppleScript predicate. `Int(id)`
+    // succeeds only for `[+-]?\d+` — on failure substitute an impossible id so the
+    // malicious string is never interpolated; the script fails cleanly with -1728.
+    let safeId = Int(id) != nil ? id : "-1"
+    return "(first message of \(mailboxRefByAccountId(mailbox, accountId: accountId)) whose id is \(safeId))"
 }
 
 // MARK: - Resolvers (UUID path with display_name fallback)
@@ -86,8 +92,9 @@ func resolveMsgRef(id: String, mailbox: String, accountId: String?, accountName:
     if let aid = accountId, !aid.isEmpty {
         return msgRefByAccountId(id, mailbox: mailbox, accountId: aid)
     }
-    assert(Int(id) != nil, "resolveMsgRef called with non-numeric id '\(id)' — Server.swift handler missed validation (#50)")
-    return "(first message of \(resolveMailboxRef(mailbox: mailbox, accountId: nil, accountName: accountName)) whose id is \(id))"
+    // Release-safe guard (#118) — see msgRefByAccountId for the rationale.
+    let safeId = Int(id) != nil ? id : "-1"
+    return "(first message of \(resolveMailboxRef(mailbox: mailbox, accountId: nil, accountName: accountName)) whose id is \(safeId))"
 }
 
 /// Resolve an **account-only** AppleScript selector — just the account, not a

--- a/Tests/CheAppleMailMCPTests/AppleScriptRefBuilderTests.swift
+++ b/Tests/CheAppleMailMCPTests/AppleScriptRefBuilderTests.swift
@@ -89,6 +89,57 @@ final class AppleScriptRefBuilderTests: XCTestCase {
         )
     }
 
+    // MARK: - id injection hardening (#118 — release-safe guard, sister of #50)
+    //
+    // `resolveMsgRef` / `msgRefByAccountId` interpolate `id` unquoted into
+    // `whose id is \(id)`. The pre-#118 guard was a debug-only `assert` that
+    // compiles out under `-O`, so a release-build caller bypassing
+    // `Server.requireMessageId` could inject an AppleScript predicate. The fix:
+    // a release-safe `guard Int(id) != nil` that substitutes an impossible id
+    // (`-1`) — the malicious string is NEVER interpolated into the output.
+
+    func testMsgRefByAccountId_nonNumericId_substitutesSentinel() {
+        let ref = msgRefByAccountId("1 or true", mailbox: "INBOX", accountId: "UUID-A")
+        XCTAssertFalse(ref.contains("or true"),
+                       "non-numeric id must NOT be interpolated — predicate injection surface")
+        XCTAssertTrue(ref.contains("whose id is -1"),
+                      "non-numeric id must collapse to the impossible-id sentinel; got:\n\(ref)")
+    }
+
+    func testResolveMsgRef_uuidPath_nonNumericId_substitutesSentinel() {
+        let ref = resolveMsgRef(id: "1 or true", mailbox: "INBOX", accountId: "UUID-A",
+                                accountName: "a@b")
+        XCTAssertFalse(ref.contains("or true"),
+                       "UUID-path non-numeric id must NOT be interpolated")
+        XCTAssertTrue(ref.contains("whose id is -1"),
+                      "UUID-path non-numeric id must collapse to the sentinel; got:\n\(ref)")
+    }
+
+    func testResolveMsgRef_fallbackPath_nonNumericId_substitutesSentinel() {
+        let ref = resolveMsgRef(id: "263385) or true --", mailbox: "INBOX", accountId: nil,
+                                accountName: "alice@example.com")
+        XCTAssertFalse(ref.contains("or true"),
+                       "fallback-path non-numeric id must NOT be interpolated")
+        XCTAssertFalse(ref.contains("--"),
+                       "fallback-path injection payload must NOT survive into the script")
+        XCTAssertTrue(ref.contains("whose id is -1"),
+                      "fallback-path non-numeric id must collapse to the sentinel; got:\n\(ref)")
+    }
+
+    func testResolveMsgRef_numericId_byteEquivalencePreserved() {
+        // The valid (numeric) path must be byte-identical to pre-#118 output —
+        // the guard interpolates the ORIGINAL id string, not a round-tripped Int.
+        XCTAssertEqual(
+            resolveMsgRef(id: "263385", mailbox: "INBOX", accountId: nil,
+                          accountName: "alice@example.com"),
+            "(first message of (first mailbox of account \"alice@example.com\" whose name is \"INBOX\") whose id is 263385)"
+        )
+        XCTAssertEqual(
+            msgRefByAccountId("42", mailbox: "INBOX", accountId: "UUID-A"),
+            "(first message of (first mailbox of (account id \"UUID-A\") whose name is \"INBOX\") whose id is 42)"
+        )
+    }
+
     // MARK: - Escaping flows through both paths
 
     func testResolveMailboxRef_escapesQuotes_inBothPaths() {


### PR DESCRIPTION
Refs #118

## Summary
`resolveMsgRef` / `msgRefByAccountId` interpolate message `id` unquoted into `whose id is <id>`, guarded only by a debug-only `assert` that compiles out under `-O`. A release-build caller bypassing `Server.requireMessageId` could inject an AppleScript predicate (`id = "1 or true"`) — the #50 class.

Both `assert`s replaced with a release-safe numeric check (`Int(id) != nil ? id : "-1"`). On non-numeric `id` the builder substitutes an impossible id so the malicious string is never interpolated and the script fails cleanly with `-1728`. Zero behavior change for valid numeric ids — output byte-identical.

Option A from the issue (chokepoint guard) — chosen over Option B (`id: Int` retype) because `resolveMsgRef` has 12 production callers and a true type-safe fix cascades `String→Int` through the whole builder/controller/handler chain.

## Verification
- 6-AI verify ensemble — see issue #118 verify comment
- `swift build -c release` clean; `swift test` 427 passed / 0 failures / 8 skipped
- TDD: RED (injection test trapped on the old `assert`) → GREEN

## Checklist
- [x] Diagnose
- [x] Implement (1 commit)
- [ ] Verify (run /idd-verify #118)
- [ ] Pending: human review of this PR + close via /idd-close after merge

---
Generated by /idd-all. Per IDD discipline this PR intentionally omits an auto-close trailer — the issue is closed via /idd-close after merge to enforce the checklist gate + closing summary.