### PR TITLE
test: remove PII from fixtures + symmetrize nil/empty axis (#119)

### DIFF
--- a/Tests/CheAppleMailMCPTests/AppleScriptRefBuilderTests.swift
+++ b/Tests/CheAppleMailMCPTests/AppleScriptRefBuilderTests.swift
@@ -30,20 +30,20 @@ final class AppleScriptRefBuilderTests: XCTestCase {
     // MARK: - resolveMailboxRef
 
     func testResolveMailboxRef_uuidPath_whenAccountIdProvided() {
-        let ref = resolveMailboxRef(mailbox: "INBOX", accountId: "UUID-A", accountName: "kiki830621@gmail.com")
+        let ref = resolveMailboxRef(mailbox: "INBOX", accountId: "UUID-A", accountName: "alice@example.com")
         XCTAssertEqual(
             ref,
             "(first mailbox of (account id \"UUID-A\") whose name is \"INBOX\")",
             "Non-nil accountId MUST use the (account id \"...\") UUID selector — display_name must NOT appear"
         )
-        XCTAssertFalse(ref.contains("kiki830621@gmail.com"),
+        XCTAssertFalse(ref.contains("alice@example.com"),
                        "display_name must not leak into the UUID-path ref")
     }
 
     func testResolveMailboxRef_displayNameFallback_whenAccountIdNil() {
         XCTAssertEqual(
-            resolveMailboxRef(mailbox: "INBOX", accountId: nil, accountName: "kiki830621@gmail.com"),
-            "(first mailbox of account \"kiki830621@gmail.com\" whose name is \"INBOX\")",
+            resolveMailboxRef(mailbox: "INBOX", accountId: nil, accountName: "alice@example.com"),
+            "(first mailbox of account \"alice@example.com\" whose name is \"INBOX\")",
             "Nil accountId MUST fall back to the legacy account \"<display_name>\" form — "
             + "byte-identical to pre-sweep MailController.mailboxRef output"
         )
@@ -61,21 +61,21 @@ final class AppleScriptRefBuilderTests: XCTestCase {
 
     func testResolveMsgRef_uuidPath_whenAccountIdProvided() {
         let ref = resolveMsgRef(id: "263385", mailbox: "收件匣", accountId: "UUID-A",
-                                accountName: "kiki830621@gmail.com")
+                                accountName: "alice@example.com")
         XCTAssertEqual(
             ref,
             "(first message of (first mailbox of (account id \"UUID-A\") whose name is \"收件匣\") whose id is 263385)",
             "Non-nil accountId MUST chain msgRefByAccountId"
         )
-        XCTAssertFalse(ref.contains("kiki830621@gmail.com"),
+        XCTAssertFalse(ref.contains("alice@example.com"),
                        "display_name must not leak into the UUID-path ref")
     }
 
     func testResolveMsgRef_displayNameFallback_whenAccountIdNil() {
         XCTAssertEqual(
             resolveMsgRef(id: "263385", mailbox: "INBOX", accountId: nil,
-                          accountName: "kiki830621@gmail.com"),
-            "(first message of (first mailbox of account \"kiki830621@gmail.com\" whose name is \"INBOX\") whose id is 263385)",
+                          accountName: "alice@example.com"),
+            "(first message of (first mailbox of account \"alice@example.com\" whose name is \"INBOX\") whose id is 263385)",
             "Nil accountId MUST fall back to the legacy form — byte-identical to "
             + "pre-sweep MailController.msgRef output"
         )
@@ -160,20 +160,20 @@ final class AppleScriptRefBuilderTests: XCTestCase {
     // rather than referencing an existing mail item.
 
     func testResolveAccountRef_uuidPath_whenAccountIdProvided() {
-        let ref = resolveAccountRef(accountId: "UUID-A", accountName: "kiki830621@gmail.com")
+        let ref = resolveAccountRef(accountId: "UUID-A", accountName: "alice@example.com")
         XCTAssertEqual(
             ref,
             "(account id \"UUID-A\")",
             "Non-nil accountId MUST use the (account id \"...\") UUID selector"
         )
-        XCTAssertFalse(ref.contains("kiki830621@gmail.com"),
+        XCTAssertFalse(ref.contains("alice@example.com"),
                        "display_name must not leak into the UUID-path ref")
     }
 
     func testResolveAccountRef_displayNameFallback_whenAccountIdNil() {
         XCTAssertEqual(
-            resolveAccountRef(accountId: nil, accountName: "kiki830621@gmail.com"),
-            "account \"kiki830621@gmail.com\"",
+            resolveAccountRef(accountId: nil, accountName: "alice@example.com"),
+            "account \"alice@example.com\"",
             "Nil accountId MUST fall back to the legacy account \"<display_name>\" form"
         )
     }

--- a/Tests/CheAppleMailMCPTests/MutationToolScriptBuilderTests.swift
+++ b/Tests/CheAppleMailMCPTests/MutationToolScriptBuilderTests.swift
@@ -76,7 +76,7 @@ final class MutationToolScriptBuilderTests: XCTestCase {
 
     func testBuildSetBackgroundColorScript_displayNameFallback() {
         let s = buildSetBackgroundColorScript(id: "5", mailbox: "INBOX",
-                                              accountId: nil, accountName: "e@f", color: "green")
+                                              accountId: "", accountName: "e@f", color: "green")
         XCTAssertTrue(s.contains("account \"e@f\""))
         XCTAssertFalse(s.contains("account id "))
     }


### PR DESCRIPTION
Refs #119

## Summary
Three test-hygiene cleanups from #114's verify:
- **PII** — `AppleScriptRefBuilderTests.swift` hardcoded the project owner's real email in 12 places (the issue undercounted as 7 — it missed the `resolveAccountRef` block). All 12 replaced with the synthetic `alice@example.com`.
- **nil/"" symmetry** — the 5 `*_displayNameFallback` tests in `MutationToolScriptBuilderTests.swift` had 4×`nil` + 1×`""`; flipping `setBackgroundColor` to `""` makes them alternate, pinning both axes at the per-builder layer.
- **Redundant primitive tests** — kept as defense-in-depth per the issue's own recommendation (no action).

Test-only change, zero production code touched.

## Verification
- 6-AI verify ensemble — see issue #119 verify comment
- `swift test` — 427 passed, 0 failures, 8 skipped

## Checklist
- [x] Diagnose
- [x] Implement (1 commit)
- [ ] Verify (run /idd-verify #119)
- [ ] Pending: human review of this PR + close via /idd-close after merge

---
Generated by /idd-all. Per IDD discipline this PR intentionally omits an auto-close trailer — the issue is closed via /idd-close after merge.