### PR TITLE
fix: release-safe id guard in MailController.msgRef (#145)

### DIFF
--- a/Sources/CheAppleMailMCP/AppleScript/MailController.swift
+++ b/Sources/CheAppleMailMCP/AppleScript/MailController.swift
@@ -1493,14 +1493,15 @@ actor MailController {
     /// but `id` is the internal numeric identifier returned by search/list.
     /// We must use `first message ... whose id is N` instead of `message id N`.
     ///
-    /// Issue #50: `id` is interpolated unescaped. Server.swift's `requireMessageId`
-    /// validates Int format at the handler boundary; this assertion catches future
-    /// internal callers that bypass that validation. Use `assert` (debug-only) not
-    /// `precondition` — Server-layer throw is the user-facing contract; release
-    /// builds should not crash on internal-caller bug.
-    private func msgRef(_ id: String, mailbox: String, account: String) -> String {
-        assert(Int(id) != nil, "msgRef called with non-numeric id '\(id)' — Server.swift handler missed validation (#50)")
-        return "(first message of \(mailboxRef(mailbox, account: account)) whose id is \(id))"
+    /// Issue #50 / #145: `id` is interpolated unquoted into `whose id is`. A
+    /// release-safe numeric guard rejects non-numeric `id` — `Int(id)` succeeds
+    /// only for `[+-]?\d+`; on failure an impossible id (-1) is substituted so the
+    /// malicious string is never interpolated and the script fails cleanly with
+    /// -1728. Server.swift's `requireMessageId` remains the user-facing contract.
+    /// `internal` (not `private`) purely as the #145 test seam.
+    func msgRef(_ id: String, mailbox: String, account: String) -> String {
+        let safeId = Int(id) != nil ? id : "-1"
+        return "(first message of \(mailboxRef(mailbox, account: account)) whose id is \(safeId))"
     }
 
     /// Escape special characters for AppleScript strings.

--- a/Tests/CheAppleMailMCPTests/MailControllerMsgRefTests.swift
+++ b/Tests/CheAppleMailMCPTests/MailControllerMsgRefTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import CheAppleMailMCP
+
+/// Tests for `MailController.msgRef`'s release-safe id guard (#145 — sister of
+/// #118, which hardened the identical pattern in `AppleScriptRefBuilder`).
+///
+/// `msgRef` interpolates message `id` unquoted into `whose id is <id>`. The
+/// pre-#145 guard was a debug-only `assert` that compiles out under `-O`, so a
+/// release-build caller bypassing `Server.requireMessageId` could inject an
+/// AppleScript predicate. The fix substitutes an impossible id (`-1`) for any
+/// non-numeric input — the malicious string is never interpolated.
+///
+/// `msgRef` is `internal` (not `private`) purely as the test seam; it is an
+/// actor-isolated method on `MailController`, exercised here via the shared
+/// instance (it is pure — no actor state, no I/O — so the hop is trivial).
+final class MailControllerMsgRefTests: XCTestCase {
+
+    func testMsgRef_nonNumericId_substitutesSentinel() async {
+        let ref = await MailController.shared.msgRef(
+            "1 or true", mailbox: "INBOX", account: "alice@example.com")
+        XCTAssertFalse(ref.contains("or true"),
+                       "non-numeric id must NOT be interpolated — predicate injection surface")
+        XCTAssertTrue(ref.contains("whose id is -1"),
+                      "non-numeric id must collapse to the impossible-id sentinel; got:\n\(ref)")
+    }
+
+    func testMsgRef_injectionPayloadWithMetacharacters_neutralized() async {
+        let ref = await MailController.shared.msgRef(
+            "263385) or true --", mailbox: "INBOX", account: "alice@example.com")
+        XCTAssertFalse(ref.contains("or true"),
+                       "metacharacter payload must NOT survive into the script")
+        XCTAssertFalse(ref.contains("--"))
+        XCTAssertTrue(ref.contains("whose id is -1"))
+    }
+
+    func testMsgRef_numericId_byteEquivalencePreserved() async {
+        // Valid numeric id → byte-identical to the pre-#145 output (the guard
+        // interpolates the original id string, not a round-tripped Int).
+        let ref = await MailController.shared.msgRef(
+            "263385", mailbox: "INBOX", account: "alice@example.com")
+        XCTAssertEqual(
+            ref,
+            "(first message of (first mailbox of account \"alice@example.com\" whose name is \"INBOX\") whose id is 263385)"
+        )
+    }
+}


### PR DESCRIPTION
Refs #145

## Summary
`MailController.msgRef` (the legacy private message-ref builder, 6 live read-path callers) carried the identical release-unsafe debug-only `assert` that #118 removed from `AppleScriptRefBuilder`. Under `-O` the `assert` compiles out, so a caller bypassing `Server.requireMessageId` could inject an AppleScript predicate (#50 class).

Replaces the `assert` with the same release-safe guard (`Int(id) != nil ? id : "-1"`). Drops `private` → `internal` as the test seam. Byte-identical output for valid numeric ids. This is the last of the three sister functions — no unguarded `whose id is <id>` interpolation site remains.

## Verification
- 6-AI verify ensemble — see issue #145 verify comment
- `swift build -c release` clean; `swift test` 430 passed / 0 failures / 8 skipped (3 new tests)
- TDD: RED (assert trapped on injection payload) → GREEN

## Checklist
- [x] Diagnose
- [x] Implement (1 commit)
- [ ] Verify (run /idd-verify #145)
- [ ] Pending: human review of this PR + close via /idd-close after merge

---
Generated by /idd-all. Per IDD discipline this PR intentionally omits an auto-close trailer — the issue is closed via /idd-close after merge.