### PR TITLE
docs: clarify accountId population path — MailboxURL.decode not mailboxes.account_id SELECT (#113)

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,7 +436,7 @@ Mail.app's AppleScript `account "<display_name>"` selector is **not unique** whe
 
 **Discovering `account_id`**:
 
-- **From `search_emails` results** — each `SearchResult` carries an `account_id` field alongside `account_name` (populated from the `mailboxes.account_id` SQLite join). Recommended: pass it through directly.
+- **From `search_emails` results** — each `SearchResult` carries an `account_id` field alongside `account_name` (populated by decoding the account UUID from the SQLite `mailboxes.url` authority via `MailboxURL.decode` — Mail.app's storage convention encodes the account UUID in the mailbox URL authority; there is no direct `SELECT mailboxes.account_id`). Recommended: pass it through directly.
 - **Manually** — read `~/Library/Mail/V10/MailData/Signatures/AccountsMap.plist`. The top-level keys are the UUIDs; the `AccountURL` value contains the matching email address percent-encoded in the authority.
 - **In AppleScript** — `tell application "Mail" to get id of every account` returns the UUID list.
 


### PR DESCRIPTION
Refs #113

## Summary
Fixes a documentation precision issue surfaced during `#101` PR #109 Codex review (P3 finding).

`README.md`'s "Account Disambiguation" → "Discovering `account_id`" section claimed `SearchResult.accountId` is "populated from the `mailboxes.account_id` SQLite join". The actual implementation in `EnvelopeIndexReader.search()` (`EnvelopeIndexReader.swift:563-565`) decodes the account UUID from the mailbox URL authority via `MailboxURL.decode` — there is no `SELECT mailboxes.account_id` anywhere in the search SQL. Functionally equivalent (Mail.app's storage convention encodes the UUID in the URL authority) but misleading for maintainers tracing the data model.

Single-line wording fix, aligned with the already-accurate `CHANGELOG.md` `#101` entry. Zero behavior change.

## Checklist
- [x] Diagnose
- [x] Implement (1 commit)
- [ ] Verify (run /idd-verify #113)
- [ ] **Pending: human review of this PR + /idd-close after merge**

---
Generated by /idd-all on PR path. **Do NOT add 'Closes #113'** — IDD discipline requires manual /idd-close after merge.
