### PR TITLE
test: RFC 2047-encoded path-traversal defence (#124)

### DIFF
--- a/Tests/MailSQLiteTests/AttachmentExtractorTests.swift
+++ b/Tests/MailSQLiteTests/AttachmentExtractorTests.swift
@@ -674,6 +674,38 @@ final class AttachmentExtractorTests: XCTestCase {
                        "a path-traversal attachment name must not resolve to an out-of-tree file")
     }
 
+    /// #124 security defence-in-depth: an attacker sending a path-traversal
+    /// payload **encoded as an RFC 2047 encoded-word** (the new attack shape
+    /// #99 / #115 round-2 enabled by RFC 2047-decoding filename params at the
+    /// per-parameter layer) must still be rejected by the `#105` guard. The
+    /// post-decode canonical name is exactly the literal traversal string —
+    /// so the decode-then-guard chain catches it the same way as the literal
+    /// case above. Same decoy plant; only the on-wire filename shape differs.
+    /// Base64 `Li4vLi4vZGVjb3kucGRm` decodes to `../../decoy.pdf`.
+    func testAttachmentSavability_pathTraversalNameIsRejected_rfc2047EncodedPayload() throws {
+        let root = tempRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let rowId = 262401
+        // On-wire MIME header: filename="=?utf-8?B?Li4vLi4vZGVjb3kucGRm?="
+        let encodedFilename = "=?utf-8?B?Li4vLi4vZGVjb3kucGRm?="
+        let decodedCanonicalName = "../../decoy.pdf"
+        let (mailboxURL, attachmentsDir) = try installPartialEmlxWithStrippedAttachment(
+            rowId: rowId, attachmentFilename: encodedFilename, in: root
+        )
+        let partDir = attachmentsDir.appendingPathComponent("2", isDirectory: true)
+        try FileManager.default.createDirectory(at: partDir, withIntermediateDirectories: true)
+        // Same decoy plant as the literal case — escape would land at
+        // .../Attachments/decoy.pdf if the guard were missing.
+        let escapeTarget = attachmentsDir.deletingLastPathComponent()
+            .appendingPathComponent("decoy.pdf")
+        try Data("decoy".utf8).write(to: escapeTarget)
+
+        let savability = try EmlxParser.attachmentSavability(rowId: rowId, mailboxURL: mailboxURL)
+        XCTAssertEqual(savability[decodedCanonicalName], false,
+                       "an RFC 2047-encoded path-traversal payload must still be rejected after the decode pipeline canonicalises it")
+    }
+
     /// Mirror of the happy path but exercising the external-folder match
     /// against the legacy `Content-Type: name` parameter (some senders
     /// only set `name=`, not `Content-Disposition: filename=`).


### PR DESCRIPTION
Refs #124

## Summary
Test-only addition pinning the existing defence chain against a new attack shape #99 enabled.

**Background**: pre-#99 a path-traversal attacker could send `filename="../../etc/passwd"` (literal). Post-#99 the same payload can also arrive RFC 2047-encoded (`filename="=?utf-8?B?Li4vLi4vZXRjL3Bhc3N3ZA==?="`). Both shapes end up at the `#105` `externalAttachmentURL` guard as the same decoded canonical string, both rejected.

**Pre-existing defence chain** (no production change needed):
1. `MIMEParser.resolveFilename` → `decodeRFC2047IfApplicable` (post-#99 / #115 round-2) canonicalises the encoded payload to its literal form
2. `AttachmentExtractor.externalAttachmentURL` (#105) rejects any name bearing `/`, `.`, or `..`

**This PR adds 1 regression test** (`testAttachmentSavability_pathTraversalNameIsRejected_rfc2047EncodedPayload`) mirroring the existing `testAttachmentSavability_pathTraversalNameIsRejected` but with the on-wire filename in RFC 2047 base64 encoded form. Same decoy plant, same `savable: false` assertion.

## Verification
- TDD: test confirmed green on first run — pre-existing decode-then-guard chain already covers the encoded variant.
- `swift test` full suite (post-test-add): 466 tests, 0 failures, 9 skipped.

## Checklist
- [x] Diagnose (defence already present, test gap only)
- [x] Implement (1 test, no production change)
- [ ] Verify (run /idd-verify #124)
- [ ] Pending: human review, then close via /idd-close after merge

---
Generated by /idd-all. PR intentionally omits an auto-close trailer — IDD discipline closes via /idd-close after merge.