### PR TITLE
refactor: tighten RFC 2047 gate to [^?]+ + force-construct regex (#126)

### DIFF
--- a/Sources/MailSQLite/MIMEParser.swift
+++ b/Sources/MailSQLite/MIMEParser.swift
@@ -555,18 +555,37 @@ public enum MIMEParser {
     /// which the pre-#115 raw-header-level scan used to decode — once #115
     /// moved decoding from the header layer to this per-parameter layer, a
     /// whole-string gate silently dropped that attachment class.
-    private static let rfc2047EncodedWordPattern: NSRegularExpression? = {
-        let pattern = #"=\?[^?\s]+\?[BQbq]\?[^?]*\?="#
-        return try? NSRegularExpression(pattern: pattern)
+    private static let rfc2047EncodedWordPattern: NSRegularExpression = {
+        // RFC 2047 §2: `encoded-text = 1*<Any printable ASCII char except "?"
+        // and SPACE>` — the payload requires AT LEAST one character. The
+        // earlier `[^?]*` (zero-or-more) accepted a degenerate `=?utf-8?B??=`
+        // with empty payload, which has no useful decoded value (#126).
+        // Tightened to `[^?]+` to match the grammar.
+        let pattern = #"=\?[^?\s]+\?[BQbq]\?[^?]+\?="#
+        // The pattern is a hardcoded compile-time constant — a successful
+        // build implies a syntactically valid regex. If a future refactor
+        // breaks the literal, we want to fail loudly at first use rather
+        // than silently disable the second-pass decode and pretend the
+        // gate is rejecting every value (#126: lift `try?` to fail-fast).
+        do {
+            return try NSRegularExpression(pattern: pattern)
+        } catch {
+            fatalError(
+                "decodeRFC2047IfApplicable: hardcoded RFC 2047 encoded-word "
+                + "pattern failed to compile — this is a programming error in "
+                + "the pattern literal: \(error)"
+            )
+        }
     }()
 
     /// Apply `RFC822Parser.decodeRFC2047` (a partial, in-place encoded-word
     /// scanner) when `value` contains at least one well-formed RFC 2047
     /// encoded-word. See `rfc2047EncodedWordPattern` for the rationale.
     static func decodeRFC2047IfApplicable(_ value: String) -> String {
-        guard let regex = rfc2047EncodedWordPattern else { return value }
         let range = NSRange(value.startIndex..<value.endIndex, in: value)
-        guard regex.firstMatch(in: value, range: range) != nil else { return value }
+        guard rfc2047EncodedWordPattern.firstMatch(in: value, range: range) != nil else {
+            return value
+        }
         return RFC822Parser.decodeRFC2047(value)
     }
 

--- a/Tests/MailSQLiteTests/MIMEParserTests.swift
+++ b/Tests/MailSQLiteTests/MIMEParserTests.swift
@@ -687,6 +687,25 @@ final class MIMEParserTests: XCTestCase {
                        "first (stripped) occurrence must win — matches saveAttachment's parts.first")
     }
 
+    // MARK: - Gate hardening: empty payload rejection (#126)
+
+    func testResolveFilename_plainFilename_emptyEncodedWordPayload_unchanged() {
+        // #126: RFC 2047 §2 grammar requires the encoded-text to be 1+
+        // characters. The earlier gate regex used `[^?]*` (zero-or-more) so a
+        // degenerate `=?utf-8?B??=` (empty payload) matched the gate and
+        // dropped into `RFC822Parser.decodeRFC2047` for a no-op decode —
+        // wasted work + a vacuous-EW value that should never have triggered
+        // the second pass. Post-fix the gate uses `[^?]+`, so the empty
+        // payload string is left unchanged by `decodeRFC2047IfApplicable`.
+        let params: [String: String] = ["filename": "report=?utf-8?B??=.pdf"]
+        let result = MIMEParser.resolveFilename(
+            dispositionParams: params,
+            contentTypeParams: [:]
+        )
+        XCTAssertEqual(result, "report=?utf-8?B??=.pdf",
+                       "empty encoded-word payload must NOT trigger the gate (no useful decode)")
+    }
+
     // MARK: - RFC 2231 continuation on Content-Type `name*N` (#122)
 
     func testResolveFilename_contentTypeName_rfc2231WithNestedRfc2047() {


### PR DESCRIPTION
Refs #126

Two micro-hardening items from the #99 verify:

**A. Empty-payload tightened** (`[^?]*` → `[^?]+`)
The earlier gate accepted `=?utf-8?B??=` (empty payload). RFC 2047 §2 grammar requires the encoded-text to be 1+ characters. Tightened to match.

**B. `try?` lifted to force-construct**
The hardcoded compile-time pattern was wrapped in `try?` — a future refactor breaking the literal would silently disable the gate. Switched to `do/try/fatalError` so a pattern-literal programming error surfaces loudly at first call. Type changed from `NSRegularExpression?` to `NSRegularExpression`; `decodeRFC2047IfApplicable` drops its now-unreachable `guard let`.

1 new test pins the empty-payload rejection (`report=?utf-8?B??=.pdf` survives unchanged).

`swift test`: 459 tests, 0 failures, 1 skipped.

This PR intentionally omits an auto-close trailer — IDD discipline closes via /idd-close after merge.