### PR TITLE
feat(search): truncation envelope for search_emails / list_emails (#204)

### DIFF
--- a/Sources/CheAppleMailMCP/Server.swift
+++ b/Sources/CheAppleMailMCP/Server.swift
@@ -112,7 +112,7 @@ class CheAppleMailMCPServer {
             // Email Reading Tools
             Tool(
                 name: "list_emails",
-                description: "List emails in a mailbox",
+                description: "List emails in a mailbox. Returns an envelope object {results, returned, limit, truncated} (NOT a bare array): `truncated` is true when more emails matched than `limit` — raise `limit` or narrow the query to retrieve the rest. On the SQLite fast path `truncated` is definitive (limit+1 fetch); on the AppleScript fallback it is a best-effort `returned == limit` heuristic (#204).",
                 inputSchema: .object([
                     "type": .string("object"),
                     "properties": .object([
@@ -141,7 +141,7 @@ class CheAppleMailMCPServer {
             ),
             Tool(
                 name: "search_emails",
-                description: "Search emails across ALL accounts and mailboxes using fast SQLite index (millisecond speed on 250K+ emails). Supports searching by subject, sender, recipient, or all fields. Results include `account_name` (display name) AND `account_id` (Mail.app's globally-unique UUID) — pass `account_id` through to `save_attachment` / other AppleScript-routed tools when the display_name is ambiguous (multi-account-same-display_name configurations — see #101).",
+                description: "Search emails across ALL accounts and mailboxes using fast SQLite index (millisecond speed on 250K+ emails). Supports searching by subject, sender, recipient, or all fields. Results include `account_name` (display name) AND `account_id` (Mail.app's globally-unique UUID) — pass `account_id` through to `save_attachment` / other AppleScript-routed tools when the display_name is ambiguous (multi-account-same-display_name configurations — see #101). Returns an envelope object {results, returned, limit, truncated} (NOT a bare array): `truncated` is true when more emails matched than `limit` — raise `limit` or narrow the query to retrieve the rest. On the SQLite fast path `truncated` is definitive (limit+1 fetch); on the AppleScript fallback it is a best-effort `returned == limit` heuristic (#204).",
                 inputSchema: .object([
                     "type": .string("object"),
                     "properties": .object([
@@ -853,8 +853,8 @@ class CheAppleMailMCPServer {
             // "list_attachments emlx validation failed" pattern (#24).
             if let reader = indexReader {
                 do {
-                    let emails = try reader.listEmails(mailbox: mailbox, accountName: accountName, limit: limit)
-                    return formatJSON(emails)
+                    let page = try reader.listEmailsPage(mailbox: mailbox, accountName: accountName, limit: limit)
+                    return formatJSON(Self.resultEnvelope(results: page.results, limit: limit, truncated: page.truncated))
                 } catch {
                     let message = "SQLite list_emails fast path failed for "
                         + "mailbox='\(mailbox)' account='\(accountName)': "
@@ -864,7 +864,8 @@ class CheAppleMailMCPServer {
             }
             let accountId = decodeAccountId(arguments, tool: invokedTool)
             let emails = try await mailController.listEmails(mailbox: mailbox, accountName: accountName, accountId: accountId, limit: limit)
-            return formatJSON(emails)
+            // Fallback can't fetch limit+1 cheaply; truncated is best-effort heuristic (#204).
+            return formatJSON(Self.resultEnvelope(results: emails, limit: limit, truncated: emails.count >= limit))
 
         case "get_email":
             let id = try requireMessageId(arguments)
@@ -933,14 +934,15 @@ class CheAppleMailMCPServer {
                     mailbox: mailbox, dateFrom: dateFrom, dateTo: dateTo,
                     sort: sortOrder, limit: limit
                 )
-                let results = try reader.search(params)
-                let formatted: [[String: Any]] = results.map(Self.formatSearchResultForJSON)
-                return formatJSON(formatted)
+                let page = try reader.searchPage(params)
+                let formatted: [[String: Any]] = page.results.map(Self.formatSearchResultForJSON)
+                return formatJSON(Self.resultEnvelope(results: formatted, limit: limit, truncated: page.truncated))
             }
             // Fallback to AppleScript
             let accountId = decodeAccountId(arguments, tool: invokedTool)
             let results = try await mailController.searchEmails(query: query, mailbox: mailbox, accountName: accountName, accountId: accountId, limit: limit, sort: sort)
-            return formatJSON(results)
+            // Fallback can't fetch limit+1 cheaply; truncated is best-effort heuristic (#204).
+            return formatJSON(Self.resultEnvelope(results: results, limit: limit, truncated: results.count >= limit))
 
         case "get_unread_count":
             let mailbox = arguments["mailbox"]?.stringValue
@@ -1785,6 +1787,19 @@ class CheAppleMailMCPServer {
         dateFormatter.dateFormat = "yyyy-MM-dd"
         dateFormatter.timeZone = .current
         return dateFormatter.date(from: string)
+    }
+
+    /// Wrap a result array in the truncation envelope (#204) so callers can
+    /// detect when more rows matched than were returned instead of silently
+    /// losing them. `truncated` is definitive on the SQLite fast path (limit+1
+    /// fetch) and best-effort (`returned == limit`) on the AppleScript fallback.
+    static func resultEnvelope(results: [[String: Any]], limit: Int, truncated: Bool) -> [String: Any] {
+        [
+            "results": results,
+            "returned": results.count,
+            "limit": limit,
+            "truncated": truncated,
+        ]
     }
 
     private func formatJSON(_ value: Any) -> String {

--- a/Sources/CheAppleMailMCP/Server.swift
+++ b/Sources/CheAppleMailMCP/Server.swift
@@ -865,7 +865,7 @@ class CheAppleMailMCPServer {
             let accountId = decodeAccountId(arguments, tool: invokedTool)
             let emails = try await mailController.listEmails(mailbox: mailbox, accountName: accountName, accountId: accountId, limit: limit)
             // Fallback can't fetch limit+1 cheaply; truncated is best-effort heuristic (#204).
-            return formatJSON(Self.resultEnvelope(results: emails, limit: limit, truncated: emails.count >= limit))
+            return formatJSON(Self.resultEnvelope(results: emails, limit: limit, truncated: emails.count == limit))
 
         case "get_email":
             let id = try requireMessageId(arguments)
@@ -942,7 +942,7 @@ class CheAppleMailMCPServer {
             let accountId = decodeAccountId(arguments, tool: invokedTool)
             let results = try await mailController.searchEmails(query: query, mailbox: mailbox, accountName: accountName, accountId: accountId, limit: limit, sort: sort)
             // Fallback can't fetch limit+1 cheaply; truncated is best-effort heuristic (#204).
-            return formatJSON(Self.resultEnvelope(results: results, limit: limit, truncated: results.count >= limit))
+            return formatJSON(Self.resultEnvelope(results: results, limit: limit, truncated: results.count == limit))
 
         case "get_unread_count":
             let mailbox = arguments["mailbox"]?.stringValue

--- a/Sources/MailSQLite/EnvelopeIndexReader.swift
+++ b/Sources/MailSQLite/EnvelopeIndexReader.swift
@@ -249,7 +249,9 @@ public final class EnvelopeIndexReader {
     }
 
     /// List emails in a mailbox via SQLite.
-    public func listEmails(mailbox: String, accountName: String, limit: Int = 50) throws -> [[String: Any]] {
+    /// List with truncation detection: fetches up to `limit + 1` rows so the
+    /// caller can tell whether more existed than were returned (#204).
+    public func listEmailsPage(mailbox: String, accountName: String, limit: Int = 50) throws -> (results: [[String: Any]], truncated: Bool) {
         guard let db = db else { throw MailSQLiteError.queryFailed("Database not open") }
 
         var conditions = ["m.deleted = 0"]
@@ -289,7 +291,9 @@ public final class EnvelopeIndexReader {
             sqlite3_bind_text(stmt, idx, binding, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
             idx += 1
         }
-        sqlite3_bind_int(stmt, idx, Int32(limit))
+        // Fetch one extra row to detect truncation definitively (#204).
+        let fetchLimit = limit >= Int(Int32.max) ? limit : limit + 1
+        sqlite3_bind_int(stmt, idx, Int32(fetchLimit))
 
         var results: [[String: Any]] = []
         while sqlite3_step(stmt) == SQLITE_ROW {
@@ -304,7 +308,14 @@ public final class EnvelopeIndexReader {
                 "sender": sender
             ])
         }
-        return results
+        let truncated = results.count > limit
+        return (Array(results.prefix(limit)), truncated)
+    }
+
+    /// Backward-compatible array form — returns at most `limit` results without
+    /// the truncation flag. Prefer `listEmailsPage` when truncation matters (#204).
+    public func listEmails(mailbox: String, accountName: String, limit: Int = 50) throws -> [[String: Any]] {
+        try listEmailsPage(mailbox: mailbox, accountName: accountName, limit: limit).results
     }
 
     /// Get unread count via SQLite mailboxes table.
@@ -447,7 +458,9 @@ public final class EnvelopeIndexReader {
     /// - Parameter params: Search parameters (query, field, filters, sort, limit).
     /// - Returns: Array of search results.
     /// - Throws: `MailSQLiteError.queryFailed` on SQLite errors.
-    public func search(_ params: SearchParameters) throws -> [SearchResult] {
+    /// Search with truncation detection: fetches up to `limit + 1` rows so the
+    /// caller can tell whether more matched than were returned (#204).
+    public func searchPage(_ params: SearchParameters) throws -> (results: [SearchResult], truncated: Bool) {
         guard let db = db else {
             throw MailSQLiteError.queryFailed("Database not open")
         }
@@ -546,7 +559,9 @@ public final class EnvelopeIndexReader {
             sqlite3_bind_text(stmt, idx, binding, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
             idx += 1
         }
-        sqlite3_bind_int(stmt, idx, Int32(params.limit))
+        // Fetch one extra row to detect truncation definitively (#204).
+        let fetchLimit = params.limit >= Int(Int32.max) ? params.limit : params.limit + 1
+        sqlite3_bind_int(stmt, idx, Int32(fetchLimit))
 
         // Execute and collect results
         var results: [SearchResult] = []
@@ -583,7 +598,14 @@ public final class EnvelopeIndexReader {
             ))
         }
 
-        return results
+        let truncated = results.count > params.limit
+        return (Array(results.prefix(params.limit)), truncated)
+    }
+
+    /// Backward-compatible array form — returns at most `limit` results without
+    /// the truncation flag. Prefer `searchPage` when truncation matters (#204).
+    public func search(_ params: SearchParameters) throws -> [SearchResult] {
+        try searchPage(params).results
     }
 
     // MARK: - Private Helpers

--- a/Sources/MailSQLite/EnvelopeIndexReader.swift
+++ b/Sources/MailSQLite/EnvelopeIndexReader.swift
@@ -251,8 +251,12 @@ public final class EnvelopeIndexReader {
     /// List emails in a mailbox via SQLite.
     /// List with truncation detection: fetches up to `limit + 1` rows so the
     /// caller can tell whether more existed than were returned (#204).
-    public func listEmailsPage(mailbox: String, accountName: String, limit: Int = 50) throws -> (results: [[String: Any]], truncated: Bool) {
+    public func listEmailsPage(mailbox: String, accountName: String, limit rawLimit: Int = 50) throws -> (results: [[String: Any]], truncated: Bool) {
         guard let db = db else { throw MailSQLiteError.queryFailed("Database not open") }
+
+        // Clamp limit: negative would trap `prefix()`, above Int32.max-1 would
+        // overflow the `+1` bind. Negative → 0 (empty, crash-free). (#204)
+        let limit = min(max(rawLimit, 0), Int(Int32.max) - 1)
 
         var conditions = ["m.deleted = 0"]
         var bindings: [String] = []
@@ -292,7 +296,7 @@ public final class EnvelopeIndexReader {
             idx += 1
         }
         // Fetch one extra row to detect truncation definitively (#204).
-        let fetchLimit = limit >= Int(Int32.max) ? limit : limit + 1
+        let fetchLimit = limit + 1
         sqlite3_bind_int(stmt, idx, Int32(fetchLimit))
 
         var results: [[String: Any]] = []
@@ -465,6 +469,11 @@ public final class EnvelopeIndexReader {
             throw MailSQLiteError.queryFailed("Database not open")
         }
 
+        // Clamp limit before use: a negative value would trap `prefix()`, and a
+        // value above Int32.max-1 would overflow the `+1` bind. Negative → 0
+        // (empty result, crash-free). (#204 verify CRITICAL)
+        let limit = min(max(params.limit, 0), Int(Int32.max) - 1)
+
         var conditions: [String] = ["m.deleted = 0"]
         var bindings: [String] = []
         let likeQuery = "%\(params.query)%"
@@ -560,7 +569,7 @@ public final class EnvelopeIndexReader {
             idx += 1
         }
         // Fetch one extra row to detect truncation definitively (#204).
-        let fetchLimit = params.limit >= Int(Int32.max) ? params.limit : params.limit + 1
+        let fetchLimit = limit + 1
         sqlite3_bind_int(stmt, idx, Int32(fetchLimit))
 
         // Execute and collect results
@@ -598,8 +607,8 @@ public final class EnvelopeIndexReader {
             ))
         }
 
-        let truncated = results.count > params.limit
-        return (Array(results.prefix(params.limit)), truncated)
+        let truncated = results.count > limit
+        return (Array(results.prefix(limit)), truncated)
     }
 
     /// Backward-compatible array form — returns at most `limit` results without

--- a/Tests/CheAppleMailMCPTests/ResultEnvelopeTests.swift
+++ b/Tests/CheAppleMailMCPTests/ResultEnvelopeTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import CheAppleMailMCP
+
+/// Truncation-envelope shape (#204): search_emails / list_emails wrap their
+/// results in { results, returned, limit, truncated } instead of a bare array.
+final class ResultEnvelopeTests: XCTestCase {
+
+    func testEnvelopeShape_truncated() {
+        let env = CheAppleMailMCPServer.resultEnvelope(
+            results: [["id": "1"], ["id": "2"]], limit: 2, truncated: true)
+        XCTAssertEqual(Set(env.keys), ["results", "returned", "limit", "truncated"])
+        XCTAssertEqual(env["returned"] as? Int, 2)
+        XCTAssertEqual(env["limit"] as? Int, 2)
+        XCTAssertEqual(env["truncated"] as? Bool, true)
+        XCTAssertEqual((env["results"] as? [[String: Any]])?.count, 2)
+    }
+
+    func testEnvelopeShape_notTruncated_emptyResults() {
+        let env = CheAppleMailMCPServer.resultEnvelope(results: [], limit: 50, truncated: false)
+        XCTAssertEqual(env["returned"] as? Int, 0)
+        XCTAssertEqual(env["limit"] as? Int, 50)
+        XCTAssertEqual(env["truncated"] as? Bool, false)
+        XCTAssertEqual((env["results"] as? [[String: Any]])?.isEmpty, true)
+    }
+
+    func testEnvelopeSerializesToJSONObject() throws {
+        let env = CheAppleMailMCPServer.resultEnvelope(
+            results: [["id": "1", "subject": "x"]], limit: 10, truncated: false)
+        let data = try JSONSerialization.data(withJSONObject: env)
+        let back = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        XCTAssertNotNil(back?["results"])
+        XCTAssertEqual(back?["truncated"] as? Bool, false)
+    }
+}

--- a/Tests/MailSQLiteTests/SearchTruncationTests.swift
+++ b/Tests/MailSQLiteTests/SearchTruncationTests.swift
@@ -1,0 +1,116 @@
+import XCTest
+import SQLite3
+@testable import MailSQLite
+
+/// Deterministic truncation-signal tests (#204) using a hermetic temp SQLite
+/// fixture — independent of whether the host has a real Apple Mail Envelope
+/// Index, so they run in CI / non-FDA shells.
+final class SearchTruncationTests: XCTestCase {
+
+    /// Build a temp "Envelope Index" with `count` non-deleted messages whose
+    /// subject all contain "match", one sender, one mailbox (INBOX of UUID-A).
+    /// Returns the DB path; teardown removes it.
+    private func makeFixtureDB(messageCount count: Int) throws -> String {
+        let fm = FileManager.default
+        let tmpDir = fm.temporaryDirectory.appendingPathComponent(
+            "SearchTruncationTests-\(UUID().uuidString)", isDirectory: true)
+        try fm.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        addTeardownBlock { try? fm.removeItem(at: tmpDir) }
+
+        let dbPath = tmpDir.appendingPathComponent("Envelope Index").path
+        var db: OpaquePointer?
+        let flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_NOMUTEX
+        guard sqlite3_open_v2(dbPath, &db, flags, nil) == SQLITE_OK else {
+            throw NSError(domain: "SearchTruncationTests", code: 1,
+                          userInfo: [NSLocalizedDescriptionKey: "open failed at \(dbPath)"])
+        }
+        defer { sqlite3_close(db) }
+
+        var sql = """
+        CREATE TABLE subjects (ROWID INTEGER PRIMARY KEY, subject TEXT);
+        CREATE TABLE addresses (ROWID INTEGER PRIMARY KEY, address TEXT, comment TEXT);
+        CREATE TABLE mailboxes (ROWID INTEGER PRIMARY KEY, url TEXT, unread_count INTEGER DEFAULT 0);
+        CREATE TABLE messages (ROWID INTEGER PRIMARY KEY, subject INTEGER, sender INTEGER, mailbox INTEGER, date_received INTEGER, read INTEGER DEFAULT 0, flagged INTEGER DEFAULT 0, deleted INTEGER DEFAULT 0);
+        CREATE TABLE recipients (ROWID INTEGER PRIMARY KEY, message INTEGER, address INTEGER, type INTEGER, position INTEGER);
+        INSERT INTO addresses (ROWID, address, comment) VALUES (1, 'sender@example.com', 'Sender');
+        INSERT INTO mailboxes (ROWID, url, unread_count) VALUES (1, 'imap://UUID-A/INBOX', 0);
+        """
+        for i in 1...max(count, 1) where count > 0 {
+            sql += "INSERT INTO subjects (ROWID, subject) VALUES (\(i), 'match topic \(i)');\n"
+            sql += "INSERT INTO messages (ROWID, subject, sender, mailbox, date_received, deleted) VALUES (\(i), \(i), 1, 1, \(1000 + i), 0);\n"
+        }
+
+        var errMsg: UnsafeMutablePointer<Int8>?
+        guard sqlite3_exec(db, sql, nil, nil, &errMsg) == SQLITE_OK else {
+            let m = errMsg.map { String(cString: $0) } ?? "unknown"
+            throw NSError(domain: "SearchTruncationTests", code: 2,
+                          userInfo: [NSLocalizedDescriptionKey: "exec failed: \(m)"])
+        }
+        return dbPath
+    }
+
+    private func makeReader(messageCount: Int) throws -> EnvelopeIndexReader {
+        try EnvelopeIndexReader(
+            databasePath: try makeFixtureDB(messageCount: messageCount),
+            accountMapping: ["UUID-A": "Alice"])
+    }
+
+    // MARK: - searchPage
+
+    func testSearchPage_truncatedWhenMoreThanLimit() throws {
+        let reader = try makeReader(messageCount: 5)
+        let page = try reader.searchPage(SearchParameters(query: "match", field: .subject, limit: 3))
+        XCTAssertEqual(page.results.count, 3, "returns at most limit")
+        XCTAssertTrue(page.truncated, "5 matches at limit 3 must report truncated")
+    }
+
+    func testSearchPage_notTruncatedAtExactLimit() throws {
+        let reader = try makeReader(messageCount: 5)
+        let page = try reader.searchPage(SearchParameters(query: "match", field: .subject, limit: 5))
+        XCTAssertEqual(page.results.count, 5)
+        XCTAssertFalse(page.truncated, "exactly limit matches must NOT be truncated (limit+1 fetch)")
+    }
+
+    func testSearchPage_notTruncatedUnderLimit() throws {
+        let reader = try makeReader(messageCount: 5)
+        let page = try reader.searchPage(SearchParameters(query: "match", field: .subject, limit: 10))
+        XCTAssertEqual(page.results.count, 5)
+        XCTAssertFalse(page.truncated)
+    }
+
+    func testSearchPage_zeroMatchNotTruncated() throws {
+        let reader = try makeReader(messageCount: 5)
+        let page = try reader.searchPage(SearchParameters(query: "no_such_term_zzqx", field: .subject, limit: 3))
+        XCTAssertEqual(page.results.count, 0)
+        XCTAssertFalse(page.truncated)
+    }
+
+    func testSearch_backwardCompatWrapperMatchesPageResults() throws {
+        let reader = try makeReader(messageCount: 5)
+        let params = SearchParameters(query: "match", field: .subject, limit: 3)
+        XCTAssertEqual(try reader.search(params).count, try reader.searchPage(params).results.count)
+    }
+
+    // MARK: - listEmailsPage
+
+    func testListEmailsPage_truncatedWhenMoreThanLimit() throws {
+        let reader = try makeReader(messageCount: 5)
+        let page = try reader.listEmailsPage(mailbox: "INBOX", accountName: "Alice", limit: 3)
+        XCTAssertEqual(page.results.count, 3)
+        XCTAssertTrue(page.truncated)
+    }
+
+    func testListEmailsPage_notTruncatedUnderLimit() throws {
+        let reader = try makeReader(messageCount: 5)
+        let page = try reader.listEmailsPage(mailbox: "INBOX", accountName: "Alice", limit: 10)
+        XCTAssertEqual(page.results.count, 5)
+        XCTAssertFalse(page.truncated)
+    }
+
+    func testListEmails_backwardCompatWrapperMatchesPageResults() throws {
+        let reader = try makeReader(messageCount: 5)
+        XCTAssertEqual(
+            try reader.listEmails(mailbox: "INBOX", accountName: "Alice", limit: 3).count,
+            try reader.listEmailsPage(mailbox: "INBOX", accountName: "Alice", limit: 3).results.count)
+    }
+}

--- a/Tests/MailSQLiteTests/SearchTruncationTests.swift
+++ b/Tests/MailSQLiteTests/SearchTruncationTests.swift
@@ -113,4 +113,42 @@ final class SearchTruncationTests: XCTestCase {
             try reader.listEmails(mailbox: "INBOX", accountName: "Alice", limit: 3).count,
             try reader.listEmailsPage(mailbox: "INBOX", accountName: "Alice", limit: 3).results.count)
     }
+
+    // MARK: - Limit clamping (#204 verify CRITICAL: negative limit must not trap prefix())
+
+    func testSearchPage_negativeLimitDoesNotTrap() throws {
+        let reader = try makeReader(messageCount: 5)
+        // Pre-fix: limit -1 → fetchLimit 0 → Array(prefix(-1)) traps (fatal).
+        // Post-fix: clamped to 0 → empty, crash-free.
+        let page = try reader.searchPage(SearchParameters(query: "match", field: .subject, limit: -1))
+        XCTAssertEqual(page.results.count, 0)
+    }
+
+    func testListEmailsPage_negativeLimitDoesNotTrap() throws {
+        let reader = try makeReader(messageCount: 5)
+        let page = try reader.listEmailsPage(mailbox: "INBOX", accountName: "Alice", limit: -1)
+        XCTAssertEqual(page.results.count, 0)
+    }
+
+    func testSearchPage_zeroLimitNoMatchNotTruncated() throws {
+        let reader = try makeReader(messageCount: 5)
+        let page = try reader.searchPage(SearchParameters(query: "no_such_zzqx", field: .subject, limit: 0))
+        XCTAssertEqual(page.results.count, 0)
+        XCTAssertFalse(page.truncated)
+    }
+
+    func testSearchPage_zeroLimitWithMatchesIsTruncated() throws {
+        let reader = try makeReader(messageCount: 5)
+        // limit 0 + matches exist → returns nothing but signals there is more.
+        let page = try reader.searchPage(SearchParameters(query: "match", field: .subject, limit: 0))
+        XCTAssertEqual(page.results.count, 0)
+        XCTAssertTrue(page.truncated)
+    }
+
+    func testListEmailsPage_notTruncatedAtExactLimit() throws {
+        let reader = try makeReader(messageCount: 5)
+        let page = try reader.listEmailsPage(mailbox: "INBOX", accountName: "Alice", limit: 5)
+        XCTAssertEqual(page.results.count, 5)
+        XCTAssertFalse(page.truncated, "exactly limit must NOT be truncated (limit+1 fetch)")
+    }
 }

--- a/openspec/changes/search-result-truncation-signal/.openspec.yaml
+++ b/openspec/changes/search-result-truncation-signal/.openspec.yaml
@@ -1,0 +1,4 @@
+schema: spec-driven
+created: 2026-06-16
+created_by: che cheng <kiki830621@gmail.com>
+created_with: claude

--- a/openspec/changes/search-result-truncation-signal/design.md
+++ b/openspec/changes/search-result-truncation-signal/design.md
@@ -1,0 +1,41 @@
+## Context
+
+`search_emails` / `list_emails` 的 SQLite fast path 把結果用 `LIMIT ?` 截斷後以裸 JSON array 回傳，沒有任何「還有更多」的信號。LLM-driven consumer（含本 repo 的 `export_emails_markdown` 大量歸檔）拿到剛好 `limit` 筆時會誤判為完整集合而漏信。Gmail 同一封信在 inbox/Archive/All Mail 多個 mailbox 重複出現，更容易把命中數推過 limit。
+
+## Goals / Non-Goals
+
+**Goals**
+1. 呼叫端能**確定性**偵測 truncation（非 `==limit` 啟發式偽陽性）。
+2. 信號形狀對既有「case 回傳 formatJSON 字串」架構零摩擦。
+3. 每個 result element 欄位不變（沿用既有 backward-compat 契約）。
+
+**Non-Goals**
+1. Offset / cursor 分頁（pull 完整集合）。
+2. `total_matched` 總命中數（需額外 COUNT 查詢）。
+3. 改動 search 的 filter / sort / field 語意。
+
+## Decisions
+
+### D1. 確定性偵測 = 內部抓 `limit + 1`
+
+**選**：SQL `LIMIT ?` 綁 `limit + 1`，回傳前 `limit` 列，`truncated = (fetched > limit)`。
+**捨**：(a) `truncated = (returned == limit)` 啟發式 — 對「剛好等於 limit」的完整集合會偽陽性；(b) 另跑 `COUNT(*)` 取總數 — 多一次查詢、且總數非必需。
+**理由**：`limit+1` 多抓一列、成本可忽略（ORDER BY + LIMIT 已有 index），但把 truncation 從「可能」變「確定」。是用最小代價換正確性的經典做法（同 keyset pagination 的 `LIMIT n+1` 慣例）。
+
+### D2. Response = envelope `{ results, returned, limit, truncated }`
+
+**選**：search_emails / list_emails 回傳物件 envelope；`results` 仍是原 result 陣列、每個 element 欄位不變。
+**捨**：(a) 維持裸 array + 第二個 MCP content block 傳 truncated — 與「每個 dispatch case 回傳單一 formatJSON 字串、由中央 wrapper 包成單一 `.text`」的架構衝突，需重構 return path；(b) 只在 truncated 時換成物件、否則裸 array — 形狀不一致更難消費。
+**理由**：envelope 完美貼合既有 `return formatJSON(x)` pattern（case 只是改傳的物件，不動 wrapper），是最小 blast radius。對 LLM-consumed MCP tool，envelope 比裸 array 更清楚。spec 既有的 "result format backward compatibility" requirement 規範的是**每個 result element 的欄位**（不刪欄位），envelope 包一層不違反其意圖。
+**Breaking note**：response 形狀由 array → object 是 breaking change，但已在 spec delta + tool description 明示；ecosystem consumer（archive-mail skill、export 流程）改讀 `.results` 即可。
+
+### D3. AppleScript fallback 一致包 envelope（best-effort truncated）
+
+**選**：SQLite 不可用時的 AppleScript fallback 路徑也回傳同一 envelope；但 fallback 無法 `limit+1`，`truncated` 採 `returned == limit` best-effort 啟發式，tool description 標明「fallback 的 truncated 為啟發式」。
+**理由**：形狀一致比「兩條路徑不同形狀」好；fallback 是 no-FDA 的罕見退化路徑，啟發式 truncated 已足夠提示。SQLite primary path（bug 觀察到的路徑）為確定性偵測。
+
+## Risks
+
+- Response 形狀 breaking → 由 spec delta + tool description + 測試鎖定；ecosystem consumer 一行改讀 `.results`。
+- 要確保 search 的**所有 field 分支**（subject/sender/recipient/any）都套用 `limit+1`（綁定發生在共用 SQL 組裝處，單點修改即覆蓋）。
+- 不可順手改 filter/sort 語意（scope 鎖在 truncation 信號）。

--- a/openspec/changes/search-result-truncation-signal/proposal.md
+++ b/openspec/changes/search-result-truncation-signal/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+`search_emails` / `list_emails` 走 SQLite fast path 時用 `... LIMIT ?`（`EnvelopeIndexReader.search` / `listEmails`），Server 直接 `return formatJSON(emails)` 回傳**裸 JSON array**。當底層命中數 ≥ `limit`，回傳剛好 `limit` 列、且沒有任何 row count / truncation metadata。呼叫端無法分辨「剛好 N 筆」與「N+ 筆被截到 N」——這是 **silent truncation**：任何「列舉 → 批次處理」的 consumer（特別是 `export_emails_markdown` #193 的大量歸檔流程）會在 prolific sender 超過 limit 時**無聲漏信**，operator 無從得知。
+
+相關 issue：[#204](https://github.com/PsychQuant/che-apple-mail-mcp/issues/204)。同主題但不同 bug：#194（fallback 忽略 field/date filter）、#177（archive 大量歸檔 token 成本）。
+
+## What Changes
+
+- **`EnvelopeIndexReader.search` / `listEmails`**：內部抓 `limit + 1` 列，回傳前 `limit` 列 + 一個 `truncated` 旗標（`fetched > limit`）。`limit+1` 讓 truncation 偵測**確定性**（剛好 limit → 抓到 limit、`truncated=false`；更多 → 抓到 limit+1、`truncated=true`），免掉 `==limit` 偽陽性。回傳型別從裸陣列改為帶 `truncated` 的結果集。
+- **`Server.swift` search_emails / list_emails dispatch**：response 從裸 array 改成 envelope `{ "results": [...], "returned": <int>, "limit": <int>, "truncated": <bool> }`（仍用既有 `formatJSON(_:)` 字串路徑，case 只是改傳 envelope 物件而非陣列）。AppleScript fallback 路徑也包同一 envelope（fallback 無法 `limit+1`，`truncated` 採 `returned == limit` 之 best-effort 啟發式並於描述標明）。
+- **Tool descriptions**（search_emails / list_emails）：標明 envelope 形狀 + `truncated` 欄位語意 + 建議（命中 truncated 時調高 limit 或縮窄 query）。
+- **Spec**：更新 `sqlite-query-engine` 的 limiting / result-format / list-emails requirement，新增 truncation envelope 契約。
+- **Tests**：>limit → `truncated=true` 且 `returned==limit`；==limit → `truncated=false`；<limit → `truncated=false`；envelope 形狀含四個 key。
+
+**Non-Goals**：offset/cursor 分頁與 `total_matched` 總數（需額外 COUNT 查詢）此 change 不做，列為 follow-up。Truncation 信號已足以讓呼叫端偵測並調整。
+
+## Impact
+
+**Affected code**：
+- `Sources/MailSQLite/EnvelopeIndexReader.swift` — `search` / `listEmails` 的 `limit+1` 抓取 + truncation 旗標
+- `Sources/CheAppleMailMCP/Server.swift` — search_emails / list_emails dispatch 的 envelope 組裝 + tool description
+- `Tests/MailSQLiteTests/*` — truncation 偵測 + envelope 形狀測試
+- `openspec/specs/sqlite-query-engine/spec.md` — archive 時併入
+
+**Affected APIs（breaking shape change，已文件化）**：`search_emails` / `list_emails` 的 MCP response 從 bare array 變成 envelope object。每個 result element 的欄位不變（沿用 "Search result format backward compatibility"）。消費端（archive-mail skill、export 流程）需讀 `.results`。
+
+**Affected systems**：`export_emails_markdown` 大量歸檔現在能偵測 truncation 並調整；任何依 search/list 列舉再批次處理的工作流。

--- a/openspec/changes/search-result-truncation-signal/specs/sqlite-query-engine/spec.md
+++ b/openspec/changes/search-result-truncation-signal/specs/sqlite-query-engine/spec.md
@@ -1,0 +1,61 @@
+# sqlite-query-engine Specification Delta — search-result-truncation-signal
+
+## ADDED Requirements
+
+### Requirement: Search and list result truncation envelope
+
+The system SHALL return `search_emails` and `list_emails` results as a JSON envelope object with the keys `results`, `returned`, `limit`, and `truncated`, rather than a bare array. `results` SHALL be the array of result objects (each object retaining all fields defined by "Search result format backward compatibility"). `returned` SHALL be the integer count of objects in `results`. `limit` SHALL be the effective limit applied to the query. `truncated` SHALL be a boolean indicating whether more rows matched than were returned.
+
+On the SQLite fast path the system SHALL determine `truncated` definitively by fetching up to `limit + 1` rows internally, returning at most `limit`, and setting `truncated` to true when more than `limit` rows matched. On the AppleScript fallback path (when the SQLite index is unavailable) the system MAY determine `truncated` heuristically as `returned == limit`, and this heuristic nature SHALL be documented in the tool description.
+
+#### Scenario: Envelope wraps the results array
+
+- **WHEN** `search_emails` or `list_emails` returns
+- **THEN** the response is a JSON object containing `results` (array), `returned` (integer), `limit` (integer), and `truncated` (boolean), not a bare array
+- **AND** each element of `results` retains the fields `id`, `subject`, `sender`, `date_received`, `account_name`, `mailbox` (and `to` for search results)
+
+#### Scenario: Truncation detected when more than limit match (SQLite fast path)
+
+- **WHEN** `search_emails` is called with `limit: 10` and 11 or more messages match
+- **THEN** exactly 10 objects are returned in `results`
+- **AND** `truncated` is `true`
+
+#### Scenario: No truncation when matches fit within limit (SQLite fast path)
+
+- **WHEN** `search_emails` is called with `limit: 10` and exactly 10 or fewer messages match
+- **THEN** `truncated` is `false`
+
+## MODIFIED Requirements
+
+### Requirement: Search result sorting and limiting
+
+The system SHALL sort search results by `messages.date_received` in descending order by default (newest first). The system SHALL support a `sort` parameter with values `desc` (default) and `asc`. The system SHALL limit the returned results to the value of the `limit` parameter (default: 50). To signal truncation definitively, the SQLite fast path SHALL fetch up to `limit + 1` rows internally, return at most `limit` rows, and report `truncated = true` when more than `limit` rows matched (see "Search and list result truncation envelope").
+
+#### Scenario: Default sort order
+
+- **WHEN** `search_emails` is called without a `sort` parameter
+- **THEN** results are ordered by date received, newest first
+
+#### Scenario: Custom limit
+
+- **WHEN** `search_emails` is called with `limit: 10`
+- **THEN** at most 10 result objects are returned in `results`
+
+### Requirement: Search result format backward compatibility
+
+The system SHALL return search result objects with at minimum the fields: `id`, `subject`, `sender`, `date_received`, `account_name`, `mailbox`. The system SHALL additionally include a `to` field containing the primary To recipient addresses. The `id` field SHALL contain the message ROWID which is directly compatible with AppleScript's `id of message`. These result objects SHALL appear as elements of the `results` array within the truncation envelope (see "Search and list result truncation envelope"); the per-object field set is unchanged by the envelope.
+
+#### Scenario: Result fields include both legacy and new fields
+
+- **WHEN** a search returns results
+- **THEN** each object in `results` contains `id` (integer as string), `subject` (string), `sender` (email address string), `date_received` (ISO 8601 formatted string), `account_name` (human-readable string), `mailbox` (decoded mailbox name string), and `to` (array of recipient email address strings)
+
+### Requirement: List emails via SQLite
+
+The system SHALL list emails in a mailbox by querying the Envelope Index database, joining `messages`, `subjects`, `addresses`, and `mailboxes` tables. The system SHALL NOT use AppleScript for listing emails when the SQLite index is available. The system SHALL return the listing as the truncation envelope (see "Search and list result truncation envelope"), with the email objects as elements of `results`.
+
+#### Scenario: List emails in a mailbox
+
+- **WHEN** `list_emails` is called with `mailbox` and `account_name`
+- **THEN** the system returns a truncation envelope whose `results` array contains emails with id, subject, sender, and date_received, ordered by date_received descending, limited by the `limit` parameter
+- **AND** `truncated` is `true` when more than `limit` emails exist in the mailbox

--- a/openspec/changes/search-result-truncation-signal/tasks.md
+++ b/openspec/changes/search-result-truncation-signal/tasks.md
@@ -1,0 +1,26 @@
+## 1. EnvelopeIndexReader — 確定性 truncation 偵測（D1）
+
+- [x] 1.1 `search(_:)`：SQL `LIMIT ?` 綁 `params.limit + 1`，收集後若 `count > limit` 則 `truncated = true` 並只保留前 `limit` 列。回傳 `(results, truncated)`（新型別或 tuple）。
+- [x] 1.2 `listEmails(...)`：同樣 `LIMIT ?` 綁 `limit + 1` + 前 `limit` 列 + `truncated`。
+- [x] 1.3 確認所有 search field 分支（subject/sender/recipient/any）共用同一 SQL 組裝點，`limit+1` 單點覆蓋全部。
+
+## 2. Server dispatch — envelope（D2/D3）
+
+- [x] 2.1 `search_emails` SQLite 路徑：`return formatJSON(envelope)`，envelope = `{ results: [...], returned: N, limit: L, truncated: Bool }`。
+- [x] 2.2 `list_emails` SQLite 路徑：同上 envelope。
+- [x] 2.3 兩者的 AppleScript fallback 路徑：包同一 envelope，`truncated` 採 `returned == limit` best-effort（D3）。
+- [x] 2.4 更新 `search_emails` / `list_emails` tool description：標明 envelope 形狀、`truncated` 語意、命中 truncated 時的建議（調高 limit / 縮窄 query）；fallback 的 truncated 為啟發式。
+
+## 3. Tests
+
+- [x] 3.1 `search` >limit → `truncated=true` 且 `returned==limit`（fixture 造 ≥ limit+1 列）。
+- [x] 3.2 `search` ==limit → `truncated=false`（剛好 limit 列不偽陽性）。
+- [x] 3.3 `search` <limit → `truncated=false`。
+- [x] 3.4 `listEmails` 三種 truncation case 同上。
+- [x] 3.5 Server envelope 形狀測試：response 含 `results`/`returned`/`limit`/`truncated` 四個 key，`results` 為陣列、每個 element 仍含既有欄位。
+
+## 4. Spec + build verify
+
+- [~] 4.1 `openspec/specs/sqlite-query-engine/spec.md` 由 change 的 spec delta 於 archive 時併入（spectra 處理） — 由 spectra archive 於 merge 後併入 canonical spec（deferred 到 archive 時）。
+- [x] 4.2 `swift build` 通過、`swift test` 全綠（既有測試零 regression + 新增測試通過）。
+- [x] 4.3 `spectra validate search-result-truncation-signal` 通過。


### PR DESCRIPTION
## Summary

`search_emails` / `list_emails` returned a **bare JSON array** after applying SQL `LIMIT`, with no count or truncation metadata — a result of exactly `limit` rows was indistinguishable from a truncated set, so bulk/archive consumers (e.g. `export_emails_markdown` #193) silently missed emails when a prolific sender exceeded `limit`.

This adds a **detectable truncation signal**:
- `EnvelopeIndexReader.searchPage` / `listEmailsPage` fetch up to `limit + 1` rows internally, return at most `limit`, and set `truncated = (fetched > limit)` — *definitive* (no `==limit` false positive). The old `search` / `listEmails` remain as thin array wrappers (zero internal-caller churn).
- `search_emails` / `list_emails` MCP responses become an envelope `{ results, returned, limit, truncated }` (both SQLite fast path and AppleScript fallback; fallback `truncated` is a documented best-effort `== limit` heuristic). Tool descriptions document the shape + the raise-limit / narrow-query remedy.

Spec-driven (Spectra change `search-result-truncation-signal`: proposal / design / tasks + `sqlite-query-engine` spec delta — MODIFY sorting/limiting + result-format + list-emails, ADD truncation-envelope requirement).

## ⚠️ Breaking change

`search_emails` / `list_emails` responses change from a bare array to an envelope object. Per-result fields are unchanged; consumers read `.results`. Consumer/doc updates tracked in **#205** (README examples + the cross-repo `archive-mail` skill).

## Verification

6-AI `idd-verify` ensemble (5 Claude reviewers + cross-model Codex gpt-5.5) found a **CRITICAL** negative-limit crash (`Array(prefix(-1))` traps — a new crash from the `limit+1`/`prefix` change), independently corroborated by Codex and reproduced on Swift 6.2.4. Fixed in `51fa815` (clamp `limit` to `0 … Int32.max-1`, which also closes the pre-existing `Int32(limit)` overflow), plus a doc/code heuristic alignment and 5 added edge tests. Full report: #204 (verify comment).

- `swift build` clean
- `swift test` — **640 tests, 0 failures** (16 truncation/envelope tests; hermetic SQLite fixture, not FDA-gated)
- `spectra validate search-result-truncation-signal` ✅

## Test plan

- [x] searchPage/listEmailsPage truncation: `>limit` → truncated; `==limit` / `<limit` → not truncated; zero-match → not truncated
- [x] negative limit on both → no trap (empty); `limit=0` with matches → truncated
- [x] backward-compat wrappers equal `*Page().results`; envelope shape + JSON-serializable
- [x] full suite 640/0, zero regression (existing search/list tests use the array wrappers)

## Related
- #204 (this issue), #205 (consumer/doc follow-up), #193 (export_emails_markdown — the bulk archive flow that motivated this)

Refs #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)
