### PR TITLE
docs: document search_emails/list_emails truncation envelope in READMEs (#205)

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,10 +257,10 @@ Both tools return an **envelope object** `{ results, returned, limit, truncated 
 
 | Field | Meaning |
 |-------|---------|
-| `results` | Array of result objects (per-object fields unchanged — `id`, `subject`, `sender`, `date_received`, `account_name`, `account_id`, `mailbox`, …) |
+| `results` | Array of result objects (per-object fields unchanged from the pre-envelope shape). `search_emails` objects carry `id`, `subject`, `sender`, `date_received`, `account_name`, `mailbox`, `to`, plus `account_id` when the account UUID is resolvable. `list_emails` objects carry `id`, `subject`, `sender`. |
 | `returned` | Number of objects in `results` |
 | `limit` | Effective `limit` applied to the query |
-| `truncated` | `true` when more rows matched than `limit` — **raise `limit` or narrow the query** to retrieve the rest |
+| `truncated` | `true` when more results are available than were returned — **raise `limit` or narrow the query** to retrieve the rest (definitive on the SQLite fast path; a best-effort heuristic on the AppleScript fallback — see below) |
 
 `truncated` is **definitive** on the SQLite fast path (it fetches `limit + 1` internally); on the AppleScript fallback it is a best-effort `returned == limit` heuristic. Any "enumerate → batch process" consumer should check `truncated` before assuming it has the full set.
 

--- a/README.md
+++ b/README.md
@@ -251,6 +251,19 @@ reply_email(
 
 </details>
 
+### Response shape: `search_emails` / `list_emails`
+
+Both tools return an **envelope object** `{ results, returned, limit, truncated }` — **not** a bare array (changed in [v2.14.0](CHANGELOG.md), [#204](https://github.com/PsychQuant/che-apple-mail-mcp/issues/204)). Read the matches from `.results`:
+
+| Field | Meaning |
+|-------|---------|
+| `results` | Array of result objects (per-object fields unchanged — `id`, `subject`, `sender`, `date_received`, `account_name`, `account_id`, `mailbox`, …) |
+| `returned` | Number of objects in `results` |
+| `limit` | Effective `limit` applied to the query |
+| `truncated` | `true` when more rows matched than `limit` — **raise `limit` or narrow the query** to retrieve the rest |
+
+`truncated` is **definitive** on the SQLite fast path (it fetches `limit + 1` internally); on the AppleScript fallback it is a best-effort `returned == limit` heuristic. Any "enumerate → batch process" consumer should check `truncated` before assuming it has the full set.
+
 ---
 
 ## Installation
@@ -436,7 +449,7 @@ Mail.app's AppleScript `account "<display_name>"` selector is **not unique** whe
 
 **Discovering `account_id`**:
 
-- **From `search_emails` results** — each `SearchResult` carries an `account_id` field alongside `account_name` (populated by decoding the account UUID from the SQLite `mailboxes.url` authority via `MailboxURL.decode` — Mail.app's storage convention encodes the account UUID in the mailbox URL authority; there is no direct `SELECT mailboxes.account_id`). Recommended: pass it through directly.
+- **From `search_emails` results** — each object in the `results` array (a `SearchResult`) carries an `account_id` field alongside `account_name` (populated by decoding the account UUID from the SQLite `mailboxes.url` authority via `MailboxURL.decode` — Mail.app's storage convention encodes the account UUID in the mailbox URL authority; there is no direct `SELECT mailboxes.account_id`). Recommended: pass it through directly.
 - **Manually** — read `~/Library/Mail/V10/MailData/Signatures/AccountsMap.plist`. The top-level keys are the UUIDs; the `AccountURL` value contains the matching email address percent-encoded in the authority.
 - **In AppleScript** — `tell application "Mail" to get id of every account` returns the UUID list.
 

--- a/README_zh-TW.md
+++ b/README_zh-TW.md
@@ -203,6 +203,19 @@ claude mcp add --scope user --transport stdio che-apple-mail-mcp -- ~/bin/CheApp
 
 </details>
 
+### 回傳結構：`search_emails` / `list_emails`
+
+兩個工具回傳的是**信封物件（envelope）** `{ results, returned, limit, truncated }`，**不是**裸陣列（自 [v2.14.0](CHANGELOG.md)、[#204](https://github.com/PsychQuant/che-apple-mail-mcp/issues/204) 起變更）。從 `.results` 讀取符合的郵件：
+
+| 欄位 | 意義 |
+|------|------|
+| `results` | 結果物件陣列（每個物件的欄位不變——`id`、`subject`、`sender`、`date_received`、`account_name`、`account_id`、`mailbox` 等） |
+| `returned` | `results` 中的物件數量 |
+| `limit` | 此次查詢實際套用的 `limit` |
+| `truncated` | 當符合的筆數超過 `limit` 時為 `true`——**調高 `limit` 或縮小查詢範圍**以取得其餘結果 |
+
+在 SQLite 快速路徑上 `truncated` 是**確定的**（內部會多抓 `limit + 1` 筆）；在 AppleScript 後備路徑上則是盡力而為的 `returned == limit` 啟發式判斷。任何「列舉 → 批次處理」的消費端，在假設已取得完整結果集之前都應先檢查 `truncated`。
+
 ---
 
 ## 安裝方式

--- a/README_zh-TW.md
+++ b/README_zh-TW.md
@@ -209,10 +209,10 @@ claude mcp add --scope user --transport stdio che-apple-mail-mcp -- ~/bin/CheApp
 
 | 欄位 | 意義 |
 |------|------|
-| `results` | 結果物件陣列（每個物件的欄位不變——`id`、`subject`、`sender`、`date_received`、`account_name`、`account_id`、`mailbox` 等） |
+| `results` | 結果物件陣列（每個物件的欄位與信封化之前相同）。`search_emails` 的物件含 `id`、`subject`、`sender`、`date_received`、`account_name`、`mailbox`、`to`，以及可解析帳號 UUID 時的 `account_id`；`list_emails` 的物件含 `id`、`subject`、`sender`。 |
 | `returned` | `results` 中的物件數量 |
 | `limit` | 此次查詢實際套用的 `limit` |
-| `truncated` | 當符合的筆數超過 `limit` 時為 `true`——**調高 `limit` 或縮小查詢範圍**以取得其餘結果 |
+| `truncated` | 當尚有未回傳的結果時為 `true`——**調高 `limit` 或縮小查詢範圍**以取得其餘結果（SQLite 快速路徑為確定判斷，AppleScript 後備路徑為盡力而為的啟發式，見下） |
 
 在 SQLite 快速路徑上 `truncated` 是**確定的**（內部會多抓 `limit + 1` 筆）；在 AppleScript 後備路徑上則是盡力而為的 `returned == limit` 啟發式判斷。任何「列舉 → 批次處理」的消費端，在假設已取得完整結果集之前都應先檢查 `truncated`。
 


### PR DESCRIPTION
Refs #205

## Summary
Documents the `search_emails` / `list_emails` **truncation envelope** (`{ results, returned, limit, truncated }`) in the user-facing READMEs. #204 (v2.14.0) changed both tools from a bare JSON array to this envelope, but the READMEs never documented the response shape — there was no bare-array example to replace, so the drift was an *absence*. This adds:

- `README.md` — new `### Response shape: search_emails / list_emails` subsection (read `.results`; `truncated` ⇒ raise `limit` / narrow the query), mirroring the shipped tool descriptions (`Server.swift:115,144`) + the frozen `openspec/specs/sqlite-query-engine/spec.md` contract.
- `README_zh-TW.md` — parallel `### 回傳結構` note (繁中).
- `README.md` `account_id` discovery prose — made explicit the field lives on each `.results[]` object.

Cross-repo scope item (the `archive-mail` skill consuming `.results` + becoming truncation-aware) is tracked as **PsychQuant/psychquant-claude-plugins#99**.

## Checklist
- [x] Diagnose (Simple — docs/consumer-update, Layer 1 disqualifier: prose-only, no behavior change)
- [x] Implement (2 commits: docs + verify-fix)
- [x] Verify — 6-AI ensemble PASS, 0 blocking. 2 MEDIUM accuracy findings (per-tool result fields; `truncated` fallback wording) caught + fixed in-scope (`fa30d94`), re-confirmed against source. See #205 Verify comment.
- [x] **Verify-gated**: post-verify PASS = ready to merge → after merge, run /idd-close to finalize (manual gate + closing summary; no auto-close trailer)

## Related
- #204 (the envelope change), #193 (export_emails_markdown bulk archive that motivated #204)
- PsychQuant/psychquant-claude-plugins#99 (cross-repo archive-mail consumer)

---
Generated by /idd-all #205 (PR path). **Do NOT add a GitHub close trailer** — IDD requires manual /idd-close after merge.
