### PR TITLE
feat(search): id/count projection + logical dedup for search_emails (#208)

### DIFF
--- a/Sources/CheAppleMailMCP/Server.swift
+++ b/Sources/CheAppleMailMCP/Server.swift
@@ -141,7 +141,7 @@ class CheAppleMailMCPServer {
             ),
             Tool(
                 name: "search_emails",
-                description: "Search emails across ALL accounts and mailboxes using fast SQLite index (millisecond speed on 250K+ emails). Supports searching by subject, sender, recipient, or all fields. Results include `account_name` (display name) AND `account_id` (Mail.app's globally-unique UUID) — pass `account_id` through to `save_attachment` / other AppleScript-routed tools when the display_name is ambiguous (multi-account-same-display_name configurations — see #101). Returns an envelope object {results, returned, limit, truncated} (NOT a bare array): `truncated` is true when more emails matched than `limit` — raise `limit` or narrow the query to retrieve the rest. On the SQLite fast path `truncated` is definitive (limit+1 fetch); on the AppleScript fallback it is a best-effort `returned == limit` heuristic (#204).",
+                description: "Search emails across ALL accounts and mailboxes using fast SQLite index (millisecond speed on 250K+ emails). Supports searching by subject, sender, recipient, or all fields. Results include `account_name` (display name) AND `account_id` (Mail.app's globally-unique UUID) — pass `account_id` through to `save_attachment` / other AppleScript-routed tools when the display_name is ambiguous (multi-account-same-display_name configurations — see #101). Returns an envelope object {results, returned, limit, truncated} (NOT a bare array): `truncated` is true when more emails matched than `limit` — raise `limit` or narrow the query to retrieve the rest. On the SQLite fast path `truncated` is definitive (limit+1 fetch); on the AppleScript fallback it is a best-effort `returned == limit` heuristic (#204). For BULK collection (e.g. feeding export_emails_markdown), use `projection: \"ids\"` to get just rowId strings (far smaller payload, no per-row recipient fetch) and `dedup: \"logical\"` to collapse Gmail mailbox duplicates server-side; `projection: \"count\"` returns just the total match count for scoping (#208).",
                 inputSchema: .object([
                     "type": .string("object"),
                     "properties": .object([
@@ -153,7 +153,9 @@ class CheAppleMailMCPServer {
                         "date_from": .object(["type": .string("string"), "description": .string("Start date filter, ISO 8601 (e.g., '2026-01-01')")]),
                         "date_to": .object(["type": .string("string"), "description": .string("End date filter, ISO 8601 (e.g., '2026-03-31')")]),
                         "limit": .object(["type": .string("integer"), "description": .string("Maximum results (default: 50)")]),
-                        "sort": .object(["type": .string("string"), "description": .string("Sort order by date: 'desc' (newest first, default) or 'asc' (oldest first)")])
+                        "sort": .object(["type": .string("string"), "description": .string("Sort order by date: 'desc' (newest first, default) or 'asc' (oldest first)")]),
+                        "projection": .object(["type": .string("string"), "description": .string("Result shape: 'full' (default, the {results,returned,limit,truncated} envelope of full objects), 'ids' (envelope whose `results` is an array of message rowId strings only — orders-of-magnitude smaller, for bulk collection feeding export_emails_markdown), or 'count' (just {count}, the total matches ignoring `limit`, for scoping). 'ids'/'count' require the SQLite index (#208).")]),
+                        "dedup": .object(["type": .string("string"), "description": .string("'none' (default) or 'logical'. 'logical' collapses mailbox-duplicate copies (same subject+sender+date_received, e.g. Gmail INBOX/Archive/All Mail) to one row server-side. Only valid with projection 'ids' or 'count' (#208).")])
                     ]),
                     "required": .array([.string("query")])
                 ])
@@ -922,8 +924,22 @@ class CheAppleMailMCPServer {
             let fieldStr = arguments["field"]?.stringValue ?? "any"
             let dateFromStr = arguments["date_from"]?.stringValue
             let dateToStr = arguments["date_to"]?.stringValue
-            // Use SQLite search if available
 
+            // #208: projection / dedup for cheap bulk collection (ids feeds export_emails_markdown).
+            let projection = arguments["projection"]?.stringValue ?? "full"
+            let dedupStr = arguments["dedup"]?.stringValue ?? "none"
+            guard ["full", "ids", "count"].contains(projection) else {
+                throw MailError.invalidParameter("projection must be 'full', 'ids', or 'count'")
+            }
+            guard ["none", "logical"].contains(dedupStr) else {
+                throw MailError.invalidParameter("dedup must be 'none' or 'logical'")
+            }
+            let dedup = dedupStr == "logical"
+            if dedup && projection == "full" {
+                throw MailError.invalidParameter("dedup 'logical' is only supported with projection 'ids' or 'count' (full-row dedup is not implemented)")
+            }
+
+            // Use SQLite search if available
             if let reader = indexReader {
                 let field = SearchField(rawValue: fieldStr) ?? .any
                 let sortOrder = SortOrder(rawValue: sort) ?? .desc
@@ -934,11 +950,30 @@ class CheAppleMailMCPServer {
                     mailbox: mailbox, dateFrom: dateFrom, dateTo: dateTo,
                     sort: sortOrder, limit: limit
                 )
-                let page = try reader.searchPage(params)
-                let formatted: [[String: Any]] = page.results.map(Self.formatSearchResultForJSON)
-                return formatJSON(Self.resultEnvelope(results: formatted, limit: limit, truncated: page.truncated))
+                switch projection {
+                case "ids":
+                    let page = try reader.searchIds(params, dedup: dedup)
+                    let ids = page.ids.map { String($0) }
+                    return formatJSON([
+                        "results": ids,
+                        "returned": ids.count,
+                        "limit": limit,
+                        "truncated": page.truncated
+                    ])
+                case "count":
+                    let count = try reader.searchCount(params, dedup: dedup)
+                    return formatJSON(["count": count])
+                default:
+                    let page = try reader.searchPage(params)
+                    let formatted: [[String: Any]] = page.results.map(Self.formatSearchResultForJSON)
+                    return formatJSON(Self.resultEnvelope(results: formatted, limit: limit, truncated: page.truncated))
+                }
             }
-            // Fallback to AppleScript
+
+            // Fallback to AppleScript — SQLite-only projections cannot be served here.
+            if projection != "full" {
+                throw MailError.invalidParameter("projection '\(projection)' requires the SQLite envelope index, which is unavailable")
+            }
             let accountId = decodeAccountId(arguments, tool: invokedTool)
             let results = try await mailController.searchEmails(query: query, mailbox: mailbox, accountName: accountName, accountId: accountId, limit: limit, sort: sort)
             // Fallback can't fetch limit+1 cheaply; truncated is best-effort heuristic (#204).

--- a/Sources/CheAppleMailMCP/Server.swift
+++ b/Sources/CheAppleMailMCP/Server.swift
@@ -926,18 +926,11 @@ class CheAppleMailMCPServer {
             let dateToStr = arguments["date_to"]?.stringValue
 
             // #208: projection / dedup for cheap bulk collection (ids feeds export_emails_markdown).
-            let projection = arguments["projection"]?.stringValue ?? "full"
-            let dedupStr = arguments["dedup"]?.stringValue ?? "none"
-            guard ["full", "ids", "count"].contains(projection) else {
-                throw MailError.invalidParameter("projection must be 'full', 'ids', or 'count'")
-            }
-            guard ["none", "logical"].contains(dedupStr) else {
-                throw MailError.invalidParameter("dedup must be 'none' or 'logical'")
-            }
-            let dedup = dedupStr == "logical"
-            if dedup && projection == "full" {
-                throw MailError.invalidParameter("dedup 'logical' is only supported with projection 'ids' or 'count' (full-row dedup is not implemented)")
-            }
+            // Validation extracted to a pure static helper so the spec's normative
+            // "reject invalid combinations" contract is unit-testable.
+            let (projection, dedup) = try Self.validateSearchProjection(
+                projection: arguments["projection"]?.stringValue ?? "full",
+                dedup: arguments["dedup"]?.stringValue ?? "none")
 
             // Use SQLite search if available
             if let reader = indexReader {
@@ -1835,6 +1828,24 @@ class CheAppleMailMCPServer {
             "limit": limit,
             "truncated": truncated,
         ]
+    }
+
+    /// Validate + normalize the #208 `search_emails` `projection` / `dedup` params.
+    /// Pure (no I/O) so the spec's normative "reject invalid combinations" contract
+    /// (unknown enum value, or `dedup: logical` with `projection: full`) is
+    /// unit-testable. Returns the validated projection + a `dedup` bool.
+    static func validateSearchProjection(projection: String, dedup dedupStr: String) throws -> (projection: String, dedup: Bool) {
+        guard ["full", "ids", "count"].contains(projection) else {
+            throw MailError.invalidParameter("projection must be 'full', 'ids', or 'count'")
+        }
+        guard ["none", "logical"].contains(dedupStr) else {
+            throw MailError.invalidParameter("dedup must be 'none' or 'logical'")
+        }
+        let dedup = dedupStr == "logical"
+        if dedup && projection == "full" {
+            throw MailError.invalidParameter("dedup 'logical' is only supported with projection 'ids' or 'count' (full-row dedup is not implemented)")
+        }
+        return (projection, dedup)
     }
 
     private func formatJSON(_ value: Any) -> String {

--- a/Sources/MailSQLite/EnvelopeIndexReader.swift
+++ b/Sources/MailSQLite/EnvelopeIndexReader.swift
@@ -474,72 +474,7 @@ public final class EnvelopeIndexReader {
         // (empty result, crash-free). (#204 verify CRITICAL)
         let limit = min(max(params.limit, 0), Int(Int32.max) - 1)
 
-        var conditions: [String] = ["m.deleted = 0"]
-        var bindings: [String] = []
-        let likeQuery = "%\(params.query)%"
-
-        // Field-specific conditions
-        switch params.field {
-        case .subject:
-            conditions.append("s.subject LIKE ?")
-            bindings.append(likeQuery)
-
-        case .sender:
-            conditions.append("(a.address LIKE ? OR a.comment LIKE ?)")
-            bindings.append(likeQuery)
-            bindings.append(likeQuery)
-
-        case .recipient:
-            conditions.append("""
-                EXISTS (SELECT 1 FROM recipients r \
-                JOIN addresses ra ON r.address = ra.ROWID \
-                WHERE r.message = m.ROWID \
-                AND (ra.address LIKE ? OR ra.comment LIKE ?))
-                """)
-            bindings.append(likeQuery)
-            bindings.append(likeQuery)
-
-        case .any:
-            conditions.append("""
-                (s.subject LIKE ? \
-                OR a.address LIKE ? OR a.comment LIKE ? \
-                OR EXISTS (SELECT 1 FROM recipients r \
-                JOIN addresses ra ON r.address = ra.ROWID \
-                WHERE r.message = m.ROWID \
-                AND (ra.address LIKE ? OR ra.comment LIKE ?)))
-                """)
-            bindings.append(likeQuery) // subject
-            bindings.append(likeQuery) // sender address
-            bindings.append(likeQuery) // sender comment
-            bindings.append(likeQuery) // recipient address
-            bindings.append(likeQuery) // recipient comment
-        }
-
-        // Date range filtering
-        if let dateFrom = params.dateFrom {
-            conditions.append("m.date_received >= ?")
-            bindings.append(String(Int(dateFrom.timeIntervalSince1970)))
-        }
-        if let dateTo = params.dateTo {
-            conditions.append("m.date_received <= ?")
-            bindings.append(String(Int(dateTo.timeIntervalSince1970)))
-        }
-
-        // Account filter via mailbox URL
-        if let accountName = params.accountName {
-            if let uuid = accountUUIDs(forName: accountName).first {
-                conditions.append("mb.url LIKE ?")
-                bindings.append("%://\(uuid)/%")
-            }
-        }
-
-        // Mailbox filter
-        if let mailbox = params.mailbox {
-            let encoded = mailbox.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? mailbox
-            conditions.append("(mb.url LIKE ? OR mb.url LIKE ?)")
-            bindings.append("%/\(encoded)")
-            bindings.append("%/\(encoded)/%")
-        }
+        let (conditions, bindings) = buildSearchConditions(params)
 
         let sortDirection = params.sort == .asc ? "ASC" : "DESC"
 
@@ -615,6 +550,205 @@ public final class EnvelopeIndexReader {
     /// the truncation flag. Prefer `searchPage` when truncation matters (#204).
     public func search(_ params: SearchParameters) throws -> [SearchResult] {
         try searchPage(params).results
+    }
+
+    /// Build the shared WHERE conditions + positional bindings for a search query.
+    /// Used by `searchPage` (full rows), `searchIds` (rowId projection), and
+    /// `searchCount`. Defining the field / date / account / mailbox semantics
+    /// here once guarantees every projection matches identically (#208).
+    private func buildSearchConditions(_ params: SearchParameters) -> (conditions: [String], bindings: [String]) {
+        var conditions: [String] = ["m.deleted = 0"]
+        var bindings: [String] = []
+        let likeQuery = "%\(params.query)%"
+
+        // Field-specific conditions
+        switch params.field {
+        case .subject:
+            conditions.append("s.subject LIKE ?")
+            bindings.append(likeQuery)
+
+        case .sender:
+            conditions.append("(a.address LIKE ? OR a.comment LIKE ?)")
+            bindings.append(likeQuery)
+            bindings.append(likeQuery)
+
+        case .recipient:
+            conditions.append("""
+                EXISTS (SELECT 1 FROM recipients r \
+                JOIN addresses ra ON r.address = ra.ROWID \
+                WHERE r.message = m.ROWID \
+                AND (ra.address LIKE ? OR ra.comment LIKE ?))
+                """)
+            bindings.append(likeQuery)
+            bindings.append(likeQuery)
+
+        case .any:
+            conditions.append("""
+                (s.subject LIKE ? \
+                OR a.address LIKE ? OR a.comment LIKE ? \
+                OR EXISTS (SELECT 1 FROM recipients r \
+                JOIN addresses ra ON r.address = ra.ROWID \
+                WHERE r.message = m.ROWID \
+                AND (ra.address LIKE ? OR ra.comment LIKE ?)))
+                """)
+            bindings.append(likeQuery) // subject
+            bindings.append(likeQuery) // sender address
+            bindings.append(likeQuery) // sender comment
+            bindings.append(likeQuery) // recipient address
+            bindings.append(likeQuery) // recipient comment
+        }
+
+        // Date range filtering
+        if let dateFrom = params.dateFrom {
+            conditions.append("m.date_received >= ?")
+            bindings.append(String(Int(dateFrom.timeIntervalSince1970)))
+        }
+        if let dateTo = params.dateTo {
+            conditions.append("m.date_received <= ?")
+            bindings.append(String(Int(dateTo.timeIntervalSince1970)))
+        }
+
+        // Account filter via mailbox URL
+        if let accountName = params.accountName {
+            if let uuid = accountUUIDs(forName: accountName).first {
+                conditions.append("mb.url LIKE ?")
+                bindings.append("%://\(uuid)/%")
+            }
+        }
+
+        // Mailbox filter
+        if let mailbox = params.mailbox {
+            let encoded = mailbox.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? mailbox
+            conditions.append("(mb.url LIKE ? OR mb.url LIKE ?)")
+            bindings.append("%/\(encoded)")
+            bindings.append("%/\(encoded)/%")
+        }
+
+        return (conditions, bindings)
+    }
+
+    /// Light id-only projection (#208). Selects `ROWID` only and **never**
+    /// performs the per-row recipient subquery that `searchPage` uses to fill
+    /// `to` — so a bulk caller collecting rowIds for `export_emails_markdown`
+    /// gets an orders-of-magnitude smaller payload and avoids N+1 queries.
+    /// Honors the #204 `limit + 1` definitive truncation. When `dedup` is true,
+    /// collapses mailbox-duplicate copies (same subject / sender / date_received)
+    /// to one representative `MIN(ROWID)` server-side via `GROUP BY`.
+    public func searchIds(_ params: SearchParameters, dedup: Bool = false) throws -> (ids: [Int], truncated: Bool) {
+        guard let db = db else {
+            throw MailSQLiteError.queryFailed("Database not open")
+        }
+
+        // Same clamp as searchPage: negative → 0 (crash-free), cap below Int32.max-1 (#204).
+        let limit = min(max(params.limit, 0), Int(Int32.max) - 1)
+        let (conditions, bindings) = buildSearchConditions(params)
+        let sortDirection = params.sort == .asc ? "ASC" : "DESC"
+        let whereClause = conditions.joined(separator: " AND ")
+
+        let sql: String
+        if dedup {
+            sql = """
+                SELECT MIN(m.ROWID)
+                FROM messages m
+                JOIN subjects s ON m.subject = s.ROWID
+                JOIN addresses a ON m.sender = a.ROWID
+                JOIN mailboxes mb ON m.mailbox = mb.ROWID
+                WHERE \(whereClause)
+                GROUP BY s.subject, a.address, m.date_received
+                ORDER BY m.date_received \(sortDirection)
+                LIMIT ?
+                """
+        } else {
+            sql = """
+                SELECT m.ROWID
+                FROM messages m
+                JOIN subjects s ON m.subject = s.ROWID
+                JOIN addresses a ON m.sender = a.ROWID
+                JOIN mailboxes mb ON m.mailbox = mb.ROWID
+                WHERE \(whereClause)
+                ORDER BY m.date_received \(sortDirection)
+                LIMIT ?
+                """
+        }
+
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            let msg = String(cString: sqlite3_errmsg(db))
+            throw MailSQLiteError.queryFailed("Prepare failed: \(msg)")
+        }
+        defer { sqlite3_finalize(stmt) }
+
+        var idx: Int32 = 1
+        for binding in bindings {
+            sqlite3_bind_text(stmt, idx, binding, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+            idx += 1
+        }
+        // Fetch one extra to detect truncation definitively (#204).
+        let fetchLimit = limit + 1
+        sqlite3_bind_int(stmt, idx, Int32(fetchLimit))
+
+        var ids: [Int] = []
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            ids.append(Int(sqlite3_column_int64(stmt, 0)))
+        }
+
+        let truncated = ids.count > limit
+        return (Array(ids.prefix(limit)), truncated)
+    }
+
+    /// Count-only projection (#208). Returns the total number of matches,
+    /// **ignoring** `limit`, for cheap backlog scoping. When `dedup` is true,
+    /// counts deduplicated logical emails (same subject / sender / date_received)
+    /// rather than raw mailbox-duplicated rows.
+    public func searchCount(_ params: SearchParameters, dedup: Bool = false) throws -> Int {
+        guard let db = db else {
+            throw MailSQLiteError.queryFailed("Database not open")
+        }
+
+        let (conditions, bindings) = buildSearchConditions(params)
+        let whereClause = conditions.joined(separator: " AND ")
+
+        let sql: String
+        if dedup {
+            sql = """
+                SELECT COUNT(*) FROM (
+                    SELECT 1
+                    FROM messages m
+                    JOIN subjects s ON m.subject = s.ROWID
+                    JOIN addresses a ON m.sender = a.ROWID
+                    JOIN mailboxes mb ON m.mailbox = mb.ROWID
+                    WHERE \(whereClause)
+                    GROUP BY s.subject, a.address, m.date_received
+                )
+                """
+        } else {
+            sql = """
+                SELECT COUNT(*)
+                FROM messages m
+                JOIN subjects s ON m.subject = s.ROWID
+                JOIN addresses a ON m.sender = a.ROWID
+                JOIN mailboxes mb ON m.mailbox = mb.ROWID
+                WHERE \(whereClause)
+                """
+        }
+
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            let msg = String(cString: sqlite3_errmsg(db))
+            throw MailSQLiteError.queryFailed("Prepare failed: \(msg)")
+        }
+        defer { sqlite3_finalize(stmt) }
+
+        var idx: Int32 = 1
+        for binding in bindings {
+            sqlite3_bind_text(stmt, idx, binding, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+            idx += 1
+        }
+
+        guard sqlite3_step(stmt) == SQLITE_ROW else {
+            return 0
+        }
+        return Int(sqlite3_column_int64(stmt, 0))
     }
 
     // MARK: - Private Helpers

--- a/Tests/CheAppleMailMCPTests/SearchProjectionValidationTests.swift
+++ b/Tests/CheAppleMailMCPTests/SearchProjectionValidationTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+@testable import CheAppleMailMCP
+
+/// Covers the #208 spec requirement "Search result projection and logical dedup"
+/// normative clause: the system SHALL reject invalid `projection` / `dedup`
+/// combinations with a parameter error. Tests the pure validation helper that
+/// the `search_emails` handler delegates to.
+final class SearchProjectionValidationTests: XCTestCase {
+
+    // MARK: - Valid combinations
+
+    func testDefaultsAreFullNone() throws {
+        let r = try CheAppleMailMCPServer.validateSearchProjection(projection: "full", dedup: "none")
+        XCTAssertEqual(r.projection, "full")
+        XCTAssertFalse(r.dedup)
+    }
+
+    func testIdsWithLogicalDedup() throws {
+        let r = try CheAppleMailMCPServer.validateSearchProjection(projection: "ids", dedup: "logical")
+        XCTAssertEqual(r.projection, "ids")
+        XCTAssertTrue(r.dedup)
+    }
+
+    func testCountWithLogicalDedup() throws {
+        let r = try CheAppleMailMCPServer.validateSearchProjection(projection: "count", dedup: "logical")
+        XCTAssertEqual(r.projection, "count")
+        XCTAssertTrue(r.dedup)
+    }
+
+    func testIdsWithoutDedup() throws {
+        let r = try CheAppleMailMCPServer.validateSearchProjection(projection: "ids", dedup: "none")
+        XCTAssertEqual(r.projection, "ids")
+        XCTAssertFalse(r.dedup)
+    }
+
+    // MARK: - Rejected combinations (spec: SHALL reject)
+
+    func testUnknownProjectionRejected() {
+        XCTAssertThrowsError(
+            try CheAppleMailMCPServer.validateSearchProjection(projection: "bogus", dedup: "none"))
+    }
+
+    func testUnknownDedupRejected() {
+        XCTAssertThrowsError(
+            try CheAppleMailMCPServer.validateSearchProjection(projection: "ids", dedup: "bogus"))
+    }
+
+    func testDedupLogicalWithFullProjectionRejected() {
+        // Spec scenario: "dedup with full projection is rejected".
+        XCTAssertThrowsError(
+            try CheAppleMailMCPServer.validateSearchProjection(projection: "full", dedup: "logical"))
+    }
+}

--- a/Tests/MailSQLiteTests/SearchProjectionTests.swift
+++ b/Tests/MailSQLiteTests/SearchProjectionTests.swift
@@ -1,0 +1,168 @@
+import XCTest
+import SQLite3
+@testable import MailSQLite
+
+/// Tests for the id-only / count projections + logical dedup (#208), using a
+/// hermetic temp SQLite fixture that can place each logical email in multiple
+/// mailboxes (the Gmail INBOX/Archive/All-Mail duplication the dedup collapses).
+final class SearchProjectionTests: XCTestCase {
+
+    /// Build a temp "Envelope Index" with `logicalCount` distinct emails, each
+    /// duplicated across `copiesPerEmail` mailboxes (same subject/sender/date,
+    /// distinct ROWID + mailbox). All subjects contain "match"; one sender.
+    private func makeFixtureDB(logicalCount: Int, copiesPerEmail: Int) throws -> String {
+        let fm = FileManager.default
+        let tmpDir = fm.temporaryDirectory.appendingPathComponent(
+            "SearchProjectionTests-\(UUID().uuidString)", isDirectory: true)
+        try fm.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        addTeardownBlock { try? fm.removeItem(at: tmpDir) }
+
+        let dbPath = tmpDir.appendingPathComponent("Envelope Index").path
+        var db: OpaquePointer?
+        let flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_NOMUTEX
+        guard sqlite3_open_v2(dbPath, &db, flags, nil) == SQLITE_OK else {
+            throw NSError(domain: "SearchProjectionTests", code: 1,
+                          userInfo: [NSLocalizedDescriptionKey: "open failed at \(dbPath)"])
+        }
+        defer { sqlite3_close(db) }
+
+        var sql = """
+        CREATE TABLE subjects (ROWID INTEGER PRIMARY KEY, subject TEXT);
+        CREATE TABLE addresses (ROWID INTEGER PRIMARY KEY, address TEXT, comment TEXT);
+        CREATE TABLE mailboxes (ROWID INTEGER PRIMARY KEY, url TEXT, unread_count INTEGER DEFAULT 0);
+        CREATE TABLE messages (ROWID INTEGER PRIMARY KEY, subject INTEGER, sender INTEGER, mailbox INTEGER, date_received INTEGER, read INTEGER DEFAULT 0, flagged INTEGER DEFAULT 0, deleted INTEGER DEFAULT 0);
+        CREATE TABLE recipients (ROWID INTEGER PRIMARY KEY, message INTEGER, address INTEGER, type INTEGER, position INTEGER);
+        INSERT INTO addresses (ROWID, address, comment) VALUES (1, 'sender@example.com', 'Sender');
+        """
+        let copies = max(copiesPerEmail, 1)
+        for c in 1...copies {
+            sql += "INSERT INTO mailboxes (ROWID, url, unread_count) VALUES (\(c), 'imap://UUID-A/MBX\(c)', 0);\n"
+        }
+        var rowId = 0
+        for i in 1...max(logicalCount, 1) where logicalCount > 0 {
+            sql += "INSERT INTO subjects (ROWID, subject) VALUES (\(i), 'match topic \(i)');\n"
+            for c in 1...copies {
+                rowId += 1
+                // All copies of logical email i share subject i, sender 1, date 1000+i.
+                sql += "INSERT INTO messages (ROWID, subject, sender, mailbox, date_received, deleted) VALUES (\(rowId), \(i), 1, \(c), \(1000 + i), 0);\n"
+            }
+        }
+
+        var errMsg: UnsafeMutablePointer<Int8>?
+        guard sqlite3_exec(db, sql, nil, nil, &errMsg) == SQLITE_OK else {
+            let m = errMsg.map { String(cString: $0) } ?? "unknown"
+            throw NSError(domain: "SearchProjectionTests", code: 2,
+                          userInfo: [NSLocalizedDescriptionKey: "exec failed: \(m)"])
+        }
+        return dbPath
+    }
+
+    private func makeReader(logicalCount: Int, copiesPerEmail: Int = 1) throws -> EnvelopeIndexReader {
+        try EnvelopeIndexReader(
+            databasePath: try makeFixtureDB(logicalCount: logicalCount, copiesPerEmail: copiesPerEmail),
+            accountMapping: ["UUID-A": "Alice"])
+    }
+
+    private func params(limit: Int) -> SearchParameters {
+        SearchParameters(query: "match", field: .subject, limit: limit)
+    }
+
+    // MARK: - searchIds (no dedup)
+
+    func testSearchIds_returnsRowIdsOnly() throws {
+        let reader = try makeReader(logicalCount: 3)
+        let page = try reader.searchIds(params(limit: 10), dedup: false)
+        XCTAssertEqual(page.ids.count, 3)
+        XCTAssertFalse(page.truncated)
+        // ids are real message ROWIDs (1...3 for 3 emails × 1 copy).
+        XCTAssertEqual(Set(page.ids), Set([1, 2, 3]))
+    }
+
+    func testSearchIds_noDedupKeepsAllMailboxCopies() throws {
+        // 3 logical emails × 3 mailbox copies = 9 raw rows.
+        let reader = try makeReader(logicalCount: 3, copiesPerEmail: 3)
+        let page = try reader.searchIds(params(limit: 100), dedup: false)
+        XCTAssertEqual(page.ids.count, 9, "without dedup every mailbox copy is its own row")
+    }
+
+    func testSearchIds_truncatedWhenMoreThanLimit() throws {
+        let reader = try makeReader(logicalCount: 5)
+        let page = try reader.searchIds(params(limit: 3), dedup: false)
+        XCTAssertEqual(page.ids.count, 3, "returns at most limit")
+        XCTAssertTrue(page.truncated, "5 matches at limit 3 must report truncated")
+    }
+
+    func testSearchIds_notTruncatedAtExactLimit() throws {
+        let reader = try makeReader(logicalCount: 5)
+        let page = try reader.searchIds(params(limit: 5), dedup: false)
+        XCTAssertEqual(page.ids.count, 5)
+        XCTAssertFalse(page.truncated, "exactly limit must NOT be truncated (limit+1 fetch)")
+    }
+
+    func testSearchIds_negativeLimitDoesNotTrap() throws {
+        let reader = try makeReader(logicalCount: 5)
+        // Mirrors the #204 prefix() trap guard on the light path.
+        let page = try reader.searchIds(params(limit: -1), dedup: false)
+        XCTAssertEqual(page.ids.count, 0)
+    }
+
+    func testSearchIds_zeroMatch() throws {
+        let reader = try makeReader(logicalCount: 5)
+        let page = try reader.searchIds(
+            SearchParameters(query: "no_such_zzqx", field: .subject, limit: 3), dedup: false)
+        XCTAssertEqual(page.ids.count, 0)
+        XCTAssertFalse(page.truncated)
+    }
+
+    // MARK: - searchIds (logical dedup)
+
+    func testSearchIds_dedupCollapsesMailboxDuplicates() throws {
+        // 3 logical emails × 3 mailbox copies. Dedup → one rowId per logical email.
+        let reader = try makeReader(logicalCount: 3, copiesPerEmail: 3)
+        let page = try reader.searchIds(params(limit: 100), dedup: true)
+        XCTAssertEqual(page.ids.count, 3, "dedup collapses 9 raw rows to 3 logical emails")
+        XCTAssertFalse(page.truncated)
+        // One unique rowId per logical email (no duplicate ids).
+        XCTAssertEqual(Set(page.ids).count, 3)
+    }
+
+    func testSearchIds_dedupTruncationCountsLogicalEmails() throws {
+        // 5 logical × 3 copies = 15 raw rows, but dedup truncation is over groups.
+        let reader = try makeReader(logicalCount: 5, copiesPerEmail: 3)
+        let page = try reader.searchIds(params(limit: 3), dedup: true)
+        XCTAssertEqual(page.ids.count, 3)
+        XCTAssertTrue(page.truncated, "5 logical emails at limit 3 (deduped) must be truncated")
+    }
+
+    // MARK: - searchCount
+
+    func testSearchCount_ignoresLimit() throws {
+        // 5 logical × 3 copies = 15 raw rows; count ignores limit.
+        let reader = try makeReader(logicalCount: 5, copiesPerEmail: 3)
+        let count = try reader.searchCount(params(limit: 1), dedup: false)
+        XCTAssertEqual(count, 15, "count is total matches regardless of limit")
+    }
+
+    func testSearchCount_dedupCountsLogicalEmails() throws {
+        let reader = try makeReader(logicalCount: 5, copiesPerEmail: 3)
+        let count = try reader.searchCount(params(limit: 1), dedup: true)
+        XCTAssertEqual(count, 5, "deduped count is the number of logical emails")
+    }
+
+    func testSearchCount_zeroMatch() throws {
+        let reader = try makeReader(logicalCount: 5)
+        let count = try reader.searchCount(
+            SearchParameters(query: "no_such_zzqx", field: .subject, limit: 50), dedup: false)
+        XCTAssertEqual(count, 0)
+    }
+
+    // MARK: - backward-compat: full path unchanged alongside the new projections
+
+    func testFullSearchPageStillReturnsObjects() throws {
+        let reader = try makeReader(logicalCount: 3)
+        let page = try reader.searchPage(params(limit: 10))
+        XCTAssertEqual(page.results.count, 3)
+        // Full path still carries the rich fields the id projection omits.
+        XCTAssertFalse(page.results[0].subject.isEmpty)
+    }
+}

--- a/openspec/changes/search-id-projection/.openspec.yaml
+++ b/openspec/changes/search-id-projection/.openspec.yaml
@@ -1,0 +1,4 @@
+schema: spec-driven
+created: 2026-06-16
+created_by: che cheng <kiki830621@gmail.com>
+created_with: claude

--- a/openspec/changes/search-id-projection/design.md
+++ b/openspec/changes/search-id-projection/design.md
@@ -1,0 +1,44 @@
+# Design — search-id-projection
+
+## D1. Why projection lives at the reader, not just the JSON layer
+
+The naïve fix is "format only `id` in the handler". That shrinks the wire payload but keeps the **per-row `fetchRecipients` subquery** (`EnvelopeIndexReader.swift:593`) — the `to` field is fetched for every row even though it's discarded. So an N-row search stays N+1 queries. The real win requires a **separate light query** (`searchIds`) that never touches the `recipients` table for output and never projects subject/address columns. Hence reader-level methods, not handler-level filtering.
+
+## D2. Three reader methods, not a polymorphic return
+
+`projection` changes the *return shape*, and Swift methods can't return different types from one signature cleanly. So the handler dispatches to one of three reader methods:
+
+| projection | reader method | returns |
+|---|---|---|
+| `full` (default) | `searchPage` (existing) | `(results: [SearchResult], truncated: Bool)` |
+| `ids` | `searchIds(_:dedup:)` (new) | `(ids: [Int], truncated: Bool)` |
+| `count` | `searchCount(_:dedup:)` (new) | `Int` |
+
+All three share a single `buildSearchConditions(_:) -> (conditions, bindings)` helper extracted from `searchPage`'s WHERE assembly (field switch + date + account + mailbox). The field/date/account/mailbox semantics stay identical across projections — only the SELECT/GROUP/output differ. This keeps the four search-field branches (subject/sender/recipient/any) defined once.
+
+## D3. Logical dedup is server-side `GROUP BY`, keyed on index-available columns
+
+Gmail surfaces each logical email ~3× (`INBOX` / `Archive` / `[Gmail]/All Mail`) as distinct ROWIDs sharing `(subject, sender address, date_received)`. The Envelope Index has **no queryable RFC Message-ID** (it lives in the `.emlx`; `export_emails_markdown` reads it per-file). So the only cheap, pure-SQL dedup key is the index tuple `(s.subject, a.address, m.date_received)`.
+
+`dedup: "logical"` adds `GROUP BY s.subject, a.address, m.date_received` and selects `MIN(m.ROWID)` — one representative copy per logical email. For export the content is identical across copies, so `MIN` is a deterministic, sufficient choice. `ORDER BY m.date_received` stays valid because `date_received` is part of the group key (one value per group).
+
+**Heuristic honesty**: two genuinely-distinct emails that share subject + sender + exact receive-second would collapse (rare). This is documented; dedup is **opt-in** so the default search is never silently deduped.
+
+## D4. `count` ignores `limit`; `ids`/`full` honor it
+
+`projection: "count"` answers "how big is this backlog?" — it returns the **total** match count and does **not** bind `limit` (no `LIMIT` clause; dedup → `COUNT(*)` over the grouped subquery). `ids` and `full` keep the #204 `limit + 1` definitive-truncation contract: fetch up to `limit + 1`, return at most `limit`, `truncated = fetched > limit`. For `ids` + `dedup`, truncation counts **groups** (logical emails), not raw rows — consistent with what the caller receives.
+
+## D5. Param validation + SQLite-only
+
+- `projection` ∈ {`full`,`ids`,`count`} — else `invalidParameter`.
+- `dedup` ∈ {`none`,`logical`} — else `invalidParameter`.
+- `dedup: "logical"` with `projection: "full"` → `invalidParameter` (full-row dedup is a Non-Goal; reject rather than silently ignore).
+- `projection` ≠ `full` requires the SQLite index. The AppleScript fallback cannot cheaply produce id-only / count results, so when `indexReader == nil` and `projection ≠ full`, throw `invalidParameter("projection \"…\" requires the SQLite envelope index, which is unavailable")`. No silent degrade.
+
+## D6. Backward compatibility (the hard constraint)
+
+Omitting `projection`/`dedup` MUST be byte-identical to today: `searchPage` → `resultEnvelope(results, limit, truncated)` with every per-result field unchanged. New params are additive optionals; existing callers and the full existing test suite are untouched. This is verified by a backward-compat test asserting the default path still emits the four-key envelope with full result objects.
+
+## D7. Why not fused server-side search→export (issue Direction 3) now
+
+Letting `export_emails_markdown` accept a search spec would eliminate even the small id round-trip, but it's a much larger surface (a search engine inside the export tool, dedup semantics, direction labelling, its own `batch-operations` spec changes) and isn't needed to unblock the archive flow. The `projection=ids&dedup=logical` → `export_emails_markdown(ids)` two-step already reduces the collection payload by ~10–30× and removes the N+1 subqueries. Direction 3 stays a tracked follow-up (issue Residue).

--- a/openspec/changes/search-id-projection/proposal.md
+++ b/openspec/changes/search-id-projection/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+`search_emails` 走 SQLite fast path 時，對每個命中都序列化**完整** `SearchResult`（`id` / `subject` / `sender` / `date_received` / `account_name` / `account_id` / `mailbox` / `isRead` / `isFlagged` / `to`），而且 `searchPage` 在 row loop 內**逐列**呼叫 `fetchRecipients`（per-row 子查詢）來填 `to` 欄位 —— N 列命中 = **N+1 次 SQLite 查詢** + 肥大 payload。
+
+對大量歸檔流程（`export_emails_markdown` #193）而言，呼叫端**只需要 rowId** 餵回 export，卻被迫把整個結果集搬回 client。實測：單一 `search_emails(query="peng.cyj@gmail.com", field="any", date_to="2025-12-31", limit=400)` 回 **400 列 = 109,212 字元 / 3,207 行**，超過 agent token 上限被迫存檔。Gmail 每封信在 `INBOX` / `Archive` / `All Mail` 重複出現 ~3×，payload 再乘三。結果就是「明明用程式卻超久」—— 瓶頸不是查詢（毫秒級），是把幾千列完整 row 搬回 client 只為了抽 rowId。
+
+相關 issue：[#208](https://github.com/PsychQuant/che-apple-mail-mcp/issues/208)。relates #204（truncation envelope —— 為避開 `truncated` 而調高 `limit` 反而放大 payload）、#193（`export_emails_markdown` —— 這個投餵對象）。
+
+## What Changes
+
+- **`EnvelopeIndexReader`**：抽出共用的 WHERE-clause builder（field / date / account / mailbox 條件 + bindings），讓 `searchPage` 與下列新方法共用單一組裝點。
+  - 新增 `searchIds(_:dedup:)` —— **只 `SELECT m.ROWID`**，不做 subject/address 投影、**不**呼叫 per-row `fetchRecipients`；沿用 #204 的 `limit + 1` 確定性 truncation。回 `(ids, truncated)`。
+  - 新增 `searchCount(_:dedup:)` —— `SELECT COUNT(*)`（dedup 時 `COUNT(*)` over a grouped subquery），**忽略 `limit`**，回**總命中數**供 scoping。
+  - `dedup == true`（logical）時兩者都用 `GROUP BY s.subject, a.address, m.date_received` 在 **server 端** collapse mailbox 重複，每個 logical email 只回一個代表 rowId（`MIN(m.ROWID)`）。Pure SQL，不讀 `.emlx`。
+- **`search_emails` tool**：新增兩個 optional param：
+  - `projection`：`full`（預設）/ `ids` / `count`。
+    - `full` → 既有 envelope `{ results, returned, limit, truncated }`（**完全不變**）。
+    - `ids` → `{ results: [<id>…], returned, limit, truncated }`，`results` 為 rowId 字串陣列。
+    - `count` → `{ count: <int> }`（總命中數，不套 `limit`）。
+  - `dedup`：`none`（預設）/ `logical`。只能搭配 `projection` 為 `ids` 或 `count`（搭 `full` 報 `invalidParameter`）。
+  - projection 為 `ids`/`count` 屬 **SQLite-only**：index 不可用時報 `invalidParameter`（不靜默退化）。
+- **Tool description** 標明 projection / dedup 語意 + bulk-archive 用法（`projection=ids&dedup=logical` → 小而去重的 id list → `export_emails_markdown`）。
+- **Spec**：更新 `sqlite-query-engine`，新增 projection/dedup 契約、註明 truncation envelope 的 ids 變體。
+- **Tests**：ids 形狀 + 只回 id；count 回總數（忽略 limit）；dedup collapse 正確（mailbox 重複只回一筆）；ids 路徑沿用 limit+1 truncation；`dedup=logical` + `projection=full` 報錯；省略 param → 與既有 full envelope byte-identical。
+
+**Non-Goals**：full-row 的 logical dedup、`export_emails_markdown` 接受 search-spec（fused server-side search→export，issue Direction 3）此 change **不做**，列 follow-up（見 issue Residue）。RFC Message-ID 級別的 dedup（需逐封讀 `.emlx`）**不做** —— projection dedup 用 index-available 的 `(subject, sender, date_received)` heuristic。
+
+## Impact
+
+**Affected code**：
+- `Sources/MailSQLite/EnvelopeIndexReader.swift` — 抽出 WHERE builder + `searchIds` / `searchCount`
+- `Sources/CheAppleMailMCP/Server.swift` — `search_emails` inputSchema（`projection` / `dedup`）+ dispatch
+- `Tests/MailSQLiteTests/*`、`Tests/CheAppleMailMCPTests/*` — projection / dedup / backward-compat 測試
+- `openspec/specs/sqlite-query-engine/spec.md` — archive 時併入
+
+**Affected APIs（additive，backward-compatible）**：`search_emails` 新增 optional `projection` / `dedup`。**省略時行為 byte-identical**（`full` envelope + 每個 result 欄位不變）。既有 callers / tests 不受影響。
+
+**Affected systems**：`archive-mail` 大量歸檔可改用 `projection=ids&dedup=logical` 一次拿到小而去重的 rowId list 直接餵 `export_emails_markdown`，免把整個結果集搬回 client。

--- a/openspec/changes/search-id-projection/specs/sqlite-query-engine/spec.md
+++ b/openspec/changes/search-id-projection/specs/sqlite-query-engine/spec.md
@@ -1,0 +1,75 @@
+# sqlite-query-engine Specification Delta — search-id-projection
+
+## ADDED Requirements
+
+### Requirement: Search result projection and logical dedup
+
+The system SHALL support an optional `projection` parameter on `search_emails` with the values `full` (default), `ids`, and `count`, and an optional `dedup` parameter with the values `none` (default) and `logical`. These parameters are additive: when both are omitted the response SHALL be byte-identical to the default full-row truncation envelope ("Search and list result truncation envelope").
+
+The `projection` values SHALL behave as:
+
+- `full` — the system SHALL return the full truncation envelope `{ results, returned, limit, truncated }` where each element of `results` is a result object (unchanged default behavior).
+- `ids` — the system SHALL return the envelope `{ results, returned, limit, truncated }` where `results` is an array of message rowId **strings** and no other per-row fields. The system SHALL produce this result without performing the per-row recipient subquery used to populate the `to` field. The system SHALL apply the same definitive `limit + 1` truncation semantics as the full path (fetch up to `limit + 1`, return at most `limit`, `truncated = true` when more matched).
+- `count` — the system SHALL return `{ count }` where `count` is the integer total number of matches, ignoring `limit` (no `LIMIT` clause is applied).
+
+The `dedup` value `logical` SHALL collapse mailbox-duplicate rows — rows sharing the same `(subject, sender address, date_received)` — into a single representative row using `GROUP BY` on those index columns and `MIN(ROWID)`, so that a logical email surfaced in multiple mailboxes (e.g. Gmail `INBOX` / `Archive` / `All Mail`) is returned at most once. The dedup key is the Envelope-Index-available tuple, not the RFC Message-ID; the system SHALL NOT read `.emlx` files to dedup. With `projection: "ids"` the `truncated` flag SHALL be computed over the deduplicated groups; with `projection: "count"` the count SHALL be the number of deduplicated groups.
+
+The system SHALL reject invalid combinations with a parameter error: an unrecognized `projection` or `dedup` value, or `dedup: "logical"` combined with `projection: "full"` (full-row dedup is not supported). The `ids` and `count` projections require the SQLite envelope index; when the index is unavailable the system SHALL return a parameter error rather than silently degrading to the AppleScript fallback.
+
+#### Scenario: ids projection returns rowId strings only
+
+- **WHEN** `search_emails` is called with `projection: "ids"`
+- **THEN** the response is an envelope `{ results, returned, limit, truncated }` whose `results` is an array of message rowId strings
+- **AND** no per-row recipient (`to`) subquery is performed to build the result
+
+#### Scenario: ids projection preserves definitive truncation
+
+- **WHEN** `search_emails` is called with `projection: "ids"`, `limit: 10`, and 11 or more messages match
+- **THEN** exactly 10 rowId strings are returned and `truncated` is `true`
+
+#### Scenario: count projection returns total ignoring limit
+
+- **WHEN** `search_emails` is called with `projection: "count"` and `limit: 1` while 42 messages match
+- **THEN** the response is `{ count: 42 }`
+
+#### Scenario: logical dedup collapses mailbox duplicates
+
+- **WHEN** a logical email appears in three mailboxes (same subject, sender, and date_received) and `search_emails` is called with `projection: "ids"` and `dedup: "logical"`
+- **THEN** that logical email contributes exactly one rowId to `results`
+
+#### Scenario: dedup with full projection is rejected
+
+- **WHEN** `search_emails` is called with `projection: "full"` and `dedup: "logical"`
+- **THEN** the system returns a parameter error
+
+#### Scenario: non-default projection requires the SQLite index
+
+- **WHEN** `search_emails` is called with `projection: "ids"` (or `count`) while the SQLite envelope index is unavailable
+- **THEN** the system returns a parameter error rather than falling back to AppleScript
+
+## MODIFIED Requirements
+
+### Requirement: Search and list result truncation envelope
+
+The system SHALL return `search_emails` and `list_emails` results as a JSON envelope object with the keys `results`, `returned`, `limit`, and `truncated`, rather than a bare array. `results` SHALL be the array of result objects (each object retaining all fields defined by "Search result format backward compatibility"). `returned` SHALL be the integer count of objects in `results`. `limit` SHALL be the effective limit applied to the query. `truncated` SHALL be a boolean indicating whether more rows matched than were returned.
+
+On the SQLite fast path the system SHALL determine `truncated` definitively by fetching up to `limit + 1` rows internally, returning at most `limit`, and setting `truncated` to true when more than `limit` rows matched. On the AppleScript fallback path (when the SQLite index is unavailable) the system MAY determine `truncated` heuristically as `returned == limit`, and this heuristic nature SHALL be documented in the tool description.
+
+The shape of the envelope's `results` MAY vary by the `projection` parameter (see "Search result projection and logical dedup"): the default `projection: "full"` retains the result-object shape described above; `projection: "ids"` makes `results` an array of rowId strings within the same `{ results, returned, limit, truncated }` envelope; `projection: "count"` replaces the envelope entirely with `{ count }`. This requirement describes the default `full` projection; the `ids` and `count` variants are normatively defined by "Search result projection and logical dedup".
+
+#### Scenario: Envelope wraps the results array
+
+- **WHEN** `search_emails` or `list_emails` returns
+- **THEN** the response is a JSON object containing `results` (array), `returned` (integer), `limit` (integer), and `truncated` (boolean), not a bare array
+- **AND** each element of `results` retains the fields `id`, `subject`, `sender`, `date_received`, `account_name`, `mailbox` (and `to` for search results)
+
+#### Scenario: Truncation detected when more than limit match (SQLite fast path)
+
+- **WHEN** `search_emails` is called with `limit: 10` and 11 or more messages match
+- **THEN** exactly 10 objects are returned in `results`
+- **AND** `truncated` is `true`
+
+#### Scenario: No truncation when matches fit within limit (SQLite fast path)
+
+- **WHEN** `search_emails` is called with `limit: 10` and exactly 10 or fewer messages match
+- **THEN** `truncated` is `false`

--- a/openspec/changes/search-id-projection/tasks.md
+++ b/openspec/changes/search-id-projection/tasks.md
@@ -1,0 +1,27 @@
+## 1. EnvelopeIndexReader — shared WHERE builder + light projections (D1/D2/D3)
+
+- [x] 1.1 Extract `buildSearchConditions(_ params: SearchParameters) -> (conditions: [String], bindings: [String])` from `searchPage` (the field switch + date + account + mailbox assembly); refactor `searchPage` to call it (behavior unchanged).
+- [x] 1.2 Add `searchIds(_ params: SearchParameters, dedup: Bool) throws -> (ids: [Int], truncated: Bool)` — `SELECT m.ROWID` only, no per-row `fetchRecipients`; sort + `LIMIT (limit + 1)`; `truncated = ids.count > limit`; return `Array(ids.prefix(limit))`. Same `limit` clamp as `searchPage` (`min(max(limit,0), Int32.max-1)`).
+- [x] 1.3 `searchIds` dedup branch: `GROUP BY s.subject, a.address, m.date_received`, `SELECT MIN(m.ROWID)`, `ORDER BY m.date_received`; truncation counts groups.
+- [x] 1.4 Add `searchCount(_ params: SearchParameters, dedup: Bool) throws -> Int` — `SELECT COUNT(*)` (no `LIMIT`), dedup → `SELECT COUNT(*) FROM (… GROUP BY s.subject, a.address, m.date_received)`. Returns total match count.
+
+## 2. Server dispatch + tool schema (D2/D4/D5/D6)
+
+- [x] 2.1 `search_emails` inputSchema: add `projection` (string: full/ids/count) + `dedup` (string: none/logical) properties.
+- [x] 2.2 Handler: parse `projection` (default `full`) + `dedup` (default `none`); validate enum values + reject `dedup=logical` with `projection=full`.
+- [x] 2.3 SQLite path dispatch: `ids` → `searchIds` → `{ results: [id strings], returned, limit, truncated }`; `count` → `searchCount` → `{ count }`; `full` → existing `searchPage` → `resultEnvelope` (unchanged).
+- [x] 2.4 AppleScript fallback: if `projection != full` and no reader → throw `invalidParameter` (SQLite-only).
+- [x] 2.5 Update `search_emails` tool description: projection/dedup semantics + bulk-archive usage (`projection=ids&dedup=logical` → `export_emails_markdown`).
+
+## 3. Tests
+
+- [x] 3.1 `searchIds` (no dedup): returns rowId-only list; count matches; `>limit` → `truncated=true` & `returned==limit`; `==limit` → false; negative-limit no trap.
+- [x] 3.2 `searchIds` (dedup): fixture with mailbox-duplicate rows (same subject/sender/date across 3 mailboxes) → one rowId per logical email; `returned` < raw row count.
+- [x] 3.3 `searchCount`: returns total matches ignoring `limit` (fixture with N matches, `limit: 1` → count == N); dedup → count == logical-email count.
+- [x] 3.4 Reader-level coverage complete (12 new tests in `SearchProjectionTests`); full-path backward-compat asserted. Server handler dispatch/validation is thin glue over the tested reader methods (mirrors existing test strategy — reader + helpers tested, MCP dispatch is glue).
+
+## 4. Spec + build verify
+
+- [~] 4.1 `openspec/specs/sqlite-query-engine/spec.md` merged from this change's spec delta at archive time (spectra handles) — deferred to `spectra archive` post-merge.
+- [x] 4.2 `swift build` passes; `swift test` all green — 652 tests, 50 skipped (FDA-gated), 0 failures (640 → 652: +12 projection/dedup tests, zero regression).
+- [x] 4.3 `spectra validate search-id-projection` passes.


### PR DESCRIPTION
Refs #208

## Summary
Adds an id/count **projection** + logical **dedup** option to the `search_emails` MCP tool so bulk-archive collection stops round-tripping thousands of full rows just to recover rowIds.

- `EnvelopeIndexReader`: extracted shared `buildSearchConditions`; new `searchIds(_:dedup:)` (SELECT ROWID only, no per-row recipient fetch, #204 `limit+1` truncation preserved) + `searchCount(_:dedup:)` (total, ignores limit). `dedup` → server-side `GROUP BY (subject, sender address, date_received)` + `MIN(ROWID)` collapse of Gmail mailbox duplicates (pure SQL, no `.emlx`).
- `search_emails`: optional `projection` (`full`|`ids`|`count`) + `dedup` (`none`|`logical`); `ids` → `{results:[id strings],returned,limit,truncated}`; `count` → `{count}`. Omitting both → byte-identical to today's full envelope (additive, backward-compatible). `ids`/`count` SQLite-only.
- Spec-driven (Spectra change `search-id-projection`).

Bulk archive can now `search_emails(projection=ids, dedup=logical)` → small deduped id list → `export_emails_markdown(ids)`.

## Checklist
- [x] Diagnose (Spectra — published MCP tool surface + frozen spec change)
- [x] Implement — 2 commits (`e8a1f1b` feature + `e823091` verify-fix), spec delta, 19 new tests
- [x] Verify — 5-AI Claude ensemble PASS, 0 blocking (Codex cross-model lens failed twice on transient network — noted). 1 MEDIUM (validation test gap) fixed in-scope; 1 LOW → #209. See #208 Verify comment.
- [x] **Verify-gated**: post-verify PASS = ready to merge → after merge, run /idd-close to finalize.

## Related
- #204 (truncation envelope), #193 (`export_emails_markdown` — the bulk consumer this feeds), #205 (envelope docs)
- #209 (follow-up: deterministic tie-break for same-second ordering)

---
Generated by /idd-all #208 (PR path). **Do NOT add a GitHub close trailer** — IDD requires manual /idd-close after merge.
