### PR TITLE
feat: --setup GUI window + check_fda tool for Full Disk Access onboarding (#213)

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,15 @@ open "x-apple.systempreferences:com.apple.preference.security?Privacy_Automation
 open "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles"
 ```
 
-macOS grants Full Disk Access to the **responsible process** — the app that *launched* this server — not to the binary itself. For an MCP server run by **Claude Code inside a terminal**, that responsible process is the **terminal** (Ghostty / Terminal / iTerm), so add **your terminal app** here and enable it. One grant on the terminal covers every MCP server it launches. (If you instead run the binary directly, or use the **Claude Desktop** bundle, add that binary — `~/bin/CheAppleMailMCP` — since it is then its own responsible process.) The FDA-denied error message resolves and names the exact responsible process for you at runtime (#214). Without Full Disk Access, read tools silently fall back to the slower AppleScript path and SQLite-only features (`projection`, `export_emails_markdown`) fail. For the direct-launch path, a Developer ID-signed build makes the grant survive version bumps — see [Signing & Notarization](#signing--notarization).
+macOS grants Full Disk Access to the **responsible process** — the app that *launched* this server — not to the binary itself. For an MCP server run by **Claude Code inside a terminal**, that responsible process is the **terminal** (Ghostty / Terminal / iTerm), so add **your terminal app** here and enable it. One grant on the terminal covers every MCP server it launches. (If you instead run the binary directly, or use the **Claude Desktop** bundle, add that binary — `~/bin/CheAppleMailMCP` — since it is then its own responsible process.) The FDA-denied error message names these candidates for you — it does **not** auto-resolve the one exact app, because macOS exposes no reliable in-process API for that (#214). Without Full Disk Access, read tools silently fall back to the slower AppleScript path and SQLite-only features (`projection`, `export_emails_markdown`) fail. For the direct-launch path, a Developer ID-signed build makes the grant survive version bumps — see [Signing & Notarization](#signing--notarization).
+
+**Guided setup** (#213) — instead of the manual steps above, the binary ships setup helpers:
+
+- **`CheAppleMailMCP --setup`** opens a small window with live Full Disk Access + Automation status, "Open Full Disk Access settings" / "Copy binary path" buttons, and it flips to "Ready ✅" the moment you grant.
+- **`CheAppleMailMCP --check-fda`** prints the status headlessly (and opens the pane if not granted) — handy from a terminal or script.
+- The **`check_fda` MCP tool** reports the same status to Claude on demand (call it when a SQLite-only feature errors).
+
+None of these can remove the single manual toggle (Apple puts FDA in the manual-only bucket alongside Accessibility / Screen Recording), but they make "what do I do?" obvious and give live feedback the instant you flip it on.
 
 ### Step 4: Restart Claude
 

--- a/README.md
+++ b/README.md
@@ -328,8 +328,8 @@ macOS grants Full Disk Access to the **responsible process** — the app that *l
 
 **Guided setup** (#213) — instead of the manual steps above, the binary ships setup helpers:
 
-- **`CheAppleMailMCP --setup`** opens a small window with live Full Disk Access + Automation status, "Open Full Disk Access settings" / "Copy binary path" buttons, and it flips to "Ready ✅" the moment you grant.
-- **`CheAppleMailMCP --check-fda`** prints the status headlessly (and opens the pane if not granted) — handy from a terminal or script.
+- **`CheAppleMailMCP --setup`** opens a small window with **live** Full Disk Access status (re-checked on a timer, flips to "Ready ✅" the moment you grant) plus an **on-demand** Automation check, and "Open Full Disk Access settings" / "Copy binary path" buttons.
+- **`CheAppleMailMCP --check-fda`** prints the status headlessly (and opens the pane when access is **denied**) — handy from a terminal or script.
 - The **`check_fda` MCP tool** reports the same status to Claude on demand (call it when a SQLite-only feature errors).
 
 None of these can remove the single manual toggle (Apple puts FDA in the manual-only bucket alongside Accessibility / Screen Recording), but they make "what do I do?" obvious and give live feedback the instant you flip it on.

--- a/Sources/CheAppleMailMCP/RunMode.swift
+++ b/Sources/CheAppleMailMCP/RunMode.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// How the binary was launched, parsed from `argv` **before** the stdio MCP
+/// server starts. `--setup` / `--check-fda` divert to the onboarding paths
+/// (#213); the default (no recognized flag) keeps the MCP stdio path
+/// byte-for-byte untouched — that path must never link the GUI runloop.
+public enum RunMode: Equatable {
+    case server        // default — the stdio MCP server
+    case setup         // --setup — the SwiftUI Full Disk Access setup window
+    case checkFDA      // --check-fda — headless one-shot status print + open the pane
+
+    /// Parse from raw `argv` (argv[0] is the binary path; flags follow). `--setup`
+    /// wins over `--check-fda` if both are somehow present (GUI is the richer path).
+    public static func parse(_ arguments: [String]) -> RunMode {
+        let flags = Set(arguments.dropFirst())
+        if flags.contains("--setup") { return .setup }
+        if flags.contains("--check-fda") { return .checkFDA }
+        return .server
+    }
+}

--- a/Sources/CheAppleMailMCP/Server.swift
+++ b/Sources/CheAppleMailMCP/Server.swift
@@ -62,6 +62,11 @@ class CheAppleMailMCPServer {
                 inputSchema: .object(["type": .string("object"), "properties": .object([:])])
             ),
             Tool(
+                name: "check_fda",
+                description: "Check whether Full Disk Access is granted (functionally probes the Apple Mail Envelope Index). Returns status plus the exact steps to grant it if not. Use when SQLite-only features (search_emails projection=ids/count, export_emails_markdown) fail with an 'unavailable' error.",
+                inputSchema: .object(["type": .string("object"), "properties": .object([:])])
+            ),
+            Tool(
                 name: "get_account_info",
                 description: "Get detailed information about a specific mail account",
                 inputSchema: .object([
@@ -773,6 +778,18 @@ class CheAppleMailMCPServer {
         // diagnostics use `invokedTool` rather than the shadowed parameter.
         let invokedTool = name
         switch name {
+        // Setup / diagnostics
+        case "check_fda":
+            let probe = FDAStatus.probe()
+            switch probe {
+            case .granted:
+                return "✅ " + FDAStatus.summary(probe)
+                    + "\nThe SQLite fast path and export_emails_markdown are available."
+            case .denied, .noMailData:
+                return "⚠️ " + FDAStatus.summary(probe) + "\n\n"
+                    + FullDiskAccessHelp.guidance(reason: "Full Disk Access is required for the SQLite fast path.")
+            }
+
         // Account Tools
         case "list_accounts":
             // Primary: AppleScript path — only way to resolve EWS display_name

--- a/Sources/CheAppleMailMCP/Server.swift
+++ b/Sources/CheAppleMailMCP/Server.swift
@@ -783,16 +783,21 @@ class CheAppleMailMCPServer {
             let probe = FDAStatus.probe()
             switch probe {
             case .granted:
+                // The probe reads the file; the SQLite open is a proxy, so phrase as
+                // "should work" rather than asserting availability (#213 verify, DA #7).
                 return "✅ " + FDAStatus.summary(probe)
-                    + "\nThe SQLite fast path and export_emails_markdown are available."
+                    + "\nThe SQLite fast path (search_emails projection, export_emails_markdown) should now work."
             case .denied:
                 return "⚠️ " + FDAStatus.summary(probe) + "\n\n"
                     + FullDiskAccessHelp.guidance(reason: "Full Disk Access is required for the SQLite fast path.")
             case .noMailData:
-                // Mail isn't set up — granting FDA would not fix anything. Don't mislead.
+                // ENOENT is ambiguous (no Mail vs FDA-denied hiding the dir) — present
+                // BOTH possibilities so an FDA-denied user isn't told the opposite of the fix.
                 return "ℹ️ " + FDAStatus.summary(probe)
-                    + "\nThere is no Apple Mail Envelope Index to read yet. Set up at least one account in"
-                    + " Mail, then re-check — FDA status can't be determined until there is mail data."
+                    + "\nIf Apple Mail IS configured, this most likely means Full Disk Access is denied"
+                    + " (a denial can hide ~/Library/Mail). Grant it:\n\n"
+                    + FullDiskAccessHelp.guidance(reason: "If Full Disk Access is the cause:")
+                    + "\n\nIf Mail genuinely isn't set up, add an account first, then re-check."
             case .undetermined:
                 // An unexpected errno, not a clear TCC denial — offer the FDA steps conditionally.
                 return "⚠️ " + FDAStatus.summary(probe)

--- a/Sources/CheAppleMailMCP/Server.swift
+++ b/Sources/CheAppleMailMCP/Server.swift
@@ -785,9 +785,20 @@ class CheAppleMailMCPServer {
             case .granted:
                 return "✅ " + FDAStatus.summary(probe)
                     + "\nThe SQLite fast path and export_emails_markdown are available."
-            case .denied, .noMailData:
+            case .denied:
                 return "⚠️ " + FDAStatus.summary(probe) + "\n\n"
                     + FullDiskAccessHelp.guidance(reason: "Full Disk Access is required for the SQLite fast path.")
+            case .noMailData:
+                // Mail isn't set up — granting FDA would not fix anything. Don't mislead.
+                return "ℹ️ " + FDAStatus.summary(probe)
+                    + "\nThere is no Apple Mail Envelope Index to read yet. Set up at least one account in"
+                    + " Mail, then re-check — FDA status can't be determined until there is mail data."
+            case .undetermined:
+                // An unexpected errno, not a clear TCC denial — offer the FDA steps conditionally.
+                return "⚠️ " + FDAStatus.summary(probe)
+                    + "\nThis is not a clear permission denial; retry first. If it persists and Full Disk"
+                    + " Access might be the cause:\n\n"
+                    + FullDiskAccessHelp.guidance(reason: "If Full Disk Access is the cause:")
             }
 
         // Account Tools

--- a/Sources/CheAppleMailMCP/SetupCLI.swift
+++ b/Sources/CheAppleMailMCP/SetupCLI.swift
@@ -1,19 +1,36 @@
 import Foundation
 import MailSQLite
 
-/// Headless `--check-fda` flow: print the Full Disk Access status + the exact
-/// grant steps, and open the settings pane. No window — for terminals, scripts,
-/// or a quick "am I set up?" check. (#213)
+/// Headless `--check-fda` flow: print the Full Disk Access status + the right
+/// next step per state, opening the settings pane only when granting FDA would
+/// actually help. No window — for terminals, scripts, or a quick check. (#213)
 enum SetupCLI {
     static func runCheckFDA() {
         let probe = FDAStatus.probe()
         print(FDAStatus.summary(probe))
-        guard probe != .granted else { return }
-        print("")
-        print(FullDiskAccessHelp.guidance(reason: "Full Disk Access is required for the SQLite fast path."))
-        print("")
-        print("Opening the Full Disk Access settings pane…")
-        openSettingsPane()
+        switch probe {
+        case .granted:
+            return
+        case .noMailData:
+            // Mail isn't set up — do NOT tell the user to grant FDA (it won't help).
+            print("")
+            print("Set up at least one account in Apple Mail, then re-run — Full Disk Access "
+                + "status can't be determined until there is mail data to read.")
+        case .denied:
+            print("")
+            print(FullDiskAccessHelp.guidance(reason: "Full Disk Access is required for the SQLite fast path."))
+            print("")
+            print("Opening the Full Disk Access settings pane…")
+            openSettingsPane()
+        case .undetermined:
+            print("")
+            print("The Envelope Index couldn't be read due to an unexpected error (not a clear "
+                + "permission denial). Retry first. If it persists and Full Disk Access might be the cause:")
+            print(FullDiskAccessHelp.guidance(reason: "If Full Disk Access is the cause:"))
+            print("")
+            print("Opening the Full Disk Access settings pane…")
+            openSettingsPane()
+        }
     }
 
     /// Open the deep-link via `/usr/bin/open` so the CLI path needs no AppKit.

--- a/Sources/CheAppleMailMCP/SetupCLI.swift
+++ b/Sources/CheAppleMailMCP/SetupCLI.swift
@@ -2,8 +2,9 @@ import Foundation
 import MailSQLite
 
 /// Headless `--check-fda` flow: print the Full Disk Access status + the right
-/// next step per state, opening the settings pane only when granting FDA would
-/// actually help. No window — for terminals, scripts, or a quick check. (#213)
+/// next step per state. It opens the settings pane **only** for `.denied` — the
+/// one state where granting FDA is unambiguously the fix. No window — for
+/// terminals, scripts, or a quick check. (#213)
 enum SetupCLI {
     static func runCheckFDA() {
         let probe = FDAStatus.probe()
@@ -12,10 +13,14 @@ enum SetupCLI {
         case .granted:
             return
         case .noMailData:
-            // Mail isn't set up — do NOT tell the user to grant FDA (it won't help).
+            // ENOENT is ambiguous (no Mail vs FDA-denied hiding ~/Library/Mail) —
+            // present both, and offer the grant steps for the FDA-denied case.
             print("")
-            print("Set up at least one account in Apple Mail, then re-run — Full Disk Access "
-                + "status can't be determined until there is mail data to read.")
+            print("If Apple Mail IS configured, this most likely means Full Disk Access is denied "
+                + "(a denial can hide ~/Library/Mail). Grant it:")
+            print(FullDiskAccessHelp.guidance(reason: "If Full Disk Access is the cause:"))
+            print("")
+            print("If Mail genuinely isn't set up, add an account first, then re-run.")
         case .denied:
             print("")
             print(FullDiskAccessHelp.guidance(reason: "Full Disk Access is required for the SQLite fast path."))
@@ -23,13 +28,12 @@ enum SetupCLI {
             print("Opening the Full Disk Access settings pane…")
             openSettingsPane()
         case .undetermined:
+            // Not a clear permission denial — print steps but DON'T auto-open the
+            // pane (it would imply this is an FDA problem when it may not be).
             print("")
             print("The Envelope Index couldn't be read due to an unexpected error (not a clear "
                 + "permission denial). Retry first. If it persists and Full Disk Access might be the cause:")
             print(FullDiskAccessHelp.guidance(reason: "If Full Disk Access is the cause:"))
-            print("")
-            print("Opening the Full Disk Access settings pane…")
-            openSettingsPane()
         }
     }
 

--- a/Sources/CheAppleMailMCP/SetupCLI.swift
+++ b/Sources/CheAppleMailMCP/SetupCLI.swift
@@ -1,0 +1,27 @@
+import Foundation
+import MailSQLite
+
+/// Headless `--check-fda` flow: print the Full Disk Access status + the exact
+/// grant steps, and open the settings pane. No window — for terminals, scripts,
+/// or a quick "am I set up?" check. (#213)
+enum SetupCLI {
+    static func runCheckFDA() {
+        let probe = FDAStatus.probe()
+        print(FDAStatus.summary(probe))
+        guard probe != .granted else { return }
+        print("")
+        print(FullDiskAccessHelp.guidance(reason: "Full Disk Access is required for the SQLite fast path."))
+        print("")
+        print("Opening the Full Disk Access settings pane…")
+        openSettingsPane()
+    }
+
+    /// Open the deep-link via `/usr/bin/open` so the CLI path needs no AppKit.
+    private static func openSettingsPane() {
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+        proc.arguments = [FullDiskAccessHelp.settingsDeepLink]
+        try? proc.run()
+        proc.waitUntilExit()
+    }
+}

--- a/Sources/CheAppleMailMCP/SetupWindow.swift
+++ b/Sources/CheAppleMailMCP/SetupWindow.swift
@@ -8,7 +8,9 @@ import SwiftUI
 /// The `--setup` GUI: a launch-on-demand window that shows live Full Disk Access
 /// + Automation status, opens the right settings pane, and re-checks on a timer
 /// so it flips to "Ready ✅" the instant the user grants. Gated behind --setup
-/// (see `RunMode`), so the stdio MCP path never links this AppKit runloop. (#213)
+/// (see `RunMode`): AppKit/SwiftUI are linked into the binary (load-time deps),
+/// but this runloop only *starts* under --setup — the stdio MCP path never enters
+/// it. (#213)
 ///
 /// The window names *candidates* (terminal / Claude Desktop / binary), it does
 /// NOT claim to auto-name the exact responsible app — there is no reliable
@@ -56,6 +58,9 @@ final class SetupModel: ObservableObject {
     private var timer: Timer?
 
     func start() {
+        // Idempotent: a view re-appear (miniaturize/deminiaturize re-runs onAppear
+        // while the @StateObject persists) must not leak a second repeating timer.
+        stop()
         refresh()
         // Live re-check so the window flips to Ready the moment the user grants.
         timer = Timer.scheduledTimer(withTimeInterval: 1.5, repeats: true) { [weak self] _ in
@@ -129,7 +134,7 @@ struct SetupView: View {
 
             // Automation
             HStack(alignment: .top, spacing: 10) {
-                dot(model.automation == true)
+                automationDot(model.automation)
                 VStack(alignment: .leading, spacing: 2) {
                     Text("Automation (control Mail.app)").bold()
                     Text(automationLabel).font(.caption).foregroundColor(.secondary)
@@ -141,8 +146,9 @@ struct SetupView: View {
             Spacer()
 
             if model.fda == .granted {
-                Text("Ready ✅ — Full Disk Access is granted. You can close this window.")
+                Text("Full Disk Access ✅ granted — the read / SQLite path is ready. (Automation, above, is a separate grant; check it if you use Mail-control features.)")
                     .foregroundColor(.green).bold()
+                    .fixedSize(horizontal: false, vertical: true)
             }
         }
         .padding(24)
@@ -162,6 +168,16 @@ struct SetupView: View {
     @ViewBuilder private func dot(_ ok: Bool) -> some View {
         Circle()
             .fill(ok ? Color.green : Color.red)
+            .frame(width: 12, height: 12)
+            .padding(.top, 3)
+    }
+
+    /// Three-state dot for Automation: gray for "not checked yet" so it doesn't
+    /// read as a red "denied" before the user has clicked Check.
+    @ViewBuilder private func automationDot(_ state: Bool?) -> some View {
+        let color: Color = state == nil ? .gray : (state! ? .green : .red)
+        Circle()
+            .fill(color)
             .frame(width: 12, height: 12)
             .padding(.top, 3)
     }

--- a/Sources/CheAppleMailMCP/SetupWindow.swift
+++ b/Sources/CheAppleMailMCP/SetupWindow.swift
@@ -1,0 +1,169 @@
+import Foundation
+import MailSQLite
+#if canImport(AppKit) && canImport(SwiftUI)
+import AppKit
+import SwiftUI
+#endif
+
+/// The `--setup` GUI: a launch-on-demand window that shows live Full Disk Access
+/// + Automation status, opens the right settings pane, and re-checks on a timer
+/// so it flips to "Ready ✅" the instant the user grants. Gated behind --setup
+/// (see `RunMode`), so the stdio MCP path never links this AppKit runloop. (#213)
+///
+/// The window names *candidates* (terminal / Claude Desktop / binary), it does
+/// NOT claim to auto-name the exact responsible app — there is no reliable
+/// in-process API for that (#214). The functional probe is the source of truth.
+enum SetupWindow {
+    @MainActor
+    static func run() {
+        #if canImport(AppKit) && canImport(SwiftUI)
+        let app = NSApplication.shared
+        app.setActivationPolicy(.regular)
+        let delegate = SetupAppDelegate()
+        app.delegate = delegate
+        app.run()
+        #else
+        // Non-GUI platform — degrade to the headless flow rather than nothing.
+        SetupCLI.runCheckFDA()
+        #endif
+    }
+}
+
+#if canImport(AppKit) && canImport(SwiftUI)
+@MainActor
+final class SetupAppDelegate: NSObject, NSApplicationDelegate {
+    private var window: NSWindow?
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        let hosting = NSHostingController(rootView: SetupView())
+        let win = NSWindow(contentViewController: hosting)
+        win.title = "CheAppleMailMCP — Full Disk Access Setup"
+        win.styleMask = [.titled, .closable, .miniaturizable]
+        win.setContentSize(NSSize(width: 480, height: 440))
+        win.center()
+        win.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+        window = win
+    }
+
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool { true }
+}
+
+@MainActor
+final class SetupModel: ObservableObject {
+    @Published var fda: FDAStatus.Probe = FDAStatus.probe()
+    @Published var automation: Bool?
+    private var timer: Timer?
+
+    func start() {
+        refresh()
+        // Live re-check so the window flips to Ready the moment the user grants.
+        timer = Timer.scheduledTimer(withTimeInterval: 1.5, repeats: true) { [weak self] _ in
+            Task { @MainActor in self?.refresh() }
+        }
+    }
+
+    func stop() {
+        timer?.invalidate()
+        timer = nil
+    }
+
+    func refresh() { fda = FDAStatus.probe() }
+
+    var binaryPath: String { FullDiskAccessHelp.binaryPath() }
+
+    func openFDASettings() {
+        if let url = URL(string: FullDiskAccessHelp.settingsDeepLink) {
+            NSWorkspace.shared.open(url)
+        }
+    }
+
+    func copyBinaryPath() {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(binaryPath, forType: .string)
+    }
+
+    /// Sending a benign Apple Event to Mail triggers the Automation prompt (the
+    /// one TCC surface that DOES auto-prompt, unlike FDA).
+    func checkAutomation() {
+        let source = "tell application \"Mail\" to get the name of every account"
+        var err: NSDictionary?
+        if let apple = NSAppleScript(source: source) {
+            _ = apple.executeAndReturnError(&err)
+            automation = (err == nil)
+        } else {
+            automation = false
+        }
+    }
+}
+
+struct SetupView: View {
+    @StateObject private var model = SetupModel()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Apple Mail access setup").font(.title2).bold()
+
+            // Full Disk Access
+            HStack(alignment: .top, spacing: 10) {
+                dot(model.fda == .granted)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Full Disk Access").bold()
+                    Text(FDAStatus.summary(model.fda))
+                        .font(.caption).foregroundColor(.secondary)
+                }
+            }
+            Text("macOS grants Full Disk Access to the app that LAUNCHED this server — your terminal (Ghostty / Terminal / iTerm) for Claude Code, or Claude Desktop. If you run the binary directly, grant the binary below. macOS can't tell us which one automatically, so add whichever launched this server.")
+                .font(.caption).foregroundColor(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            HStack {
+                Button("Open Full Disk Access settings") { model.openFDASettings() }
+                Button("Copy binary path") { model.copyBinaryPath() }
+            }
+            Text(model.binaryPath)
+                .font(.system(.caption, design: .monospaced))
+                .textSelection(.enabled)
+                .foregroundColor(.secondary)
+
+            Divider()
+
+            // Automation
+            HStack(alignment: .top, spacing: 10) {
+                dot(model.automation == true)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Automation (control Mail.app)").bold()
+                    Text(automationLabel).font(.caption).foregroundColor(.secondary)
+                }
+                Spacer()
+                Button("Check") { model.checkAutomation() }
+            }
+
+            Spacer()
+
+            if model.fda == .granted {
+                Text("Ready ✅ — Full Disk Access is granted. You can close this window.")
+                    .foregroundColor(.green).bold()
+            }
+        }
+        .padding(24)
+        .frame(minWidth: 460, minHeight: 410, alignment: .topLeading)
+        .onAppear { model.start() }
+        .onDisappear { model.stop() }
+    }
+
+    private var automationLabel: String {
+        switch model.automation {
+        case .none: return "Not checked yet (click Check — it triggers the macOS prompt)"
+        case .some(true): return "Allowed"
+        case .some(false): return "Denied"
+        }
+    }
+
+    @ViewBuilder private func dot(_ ok: Bool) -> some View {
+        Circle()
+            .fill(ok ? Color.green : Color.red)
+            .frame(width: 12, height: 12)
+            .padding(.top, 3)
+    }
+}
+#endif

--- a/Sources/CheAppleMailMCP/main.swift
+++ b/Sources/CheAppleMailMCP/main.swift
@@ -1,6 +1,16 @@
 import Foundation
 import MCP
 
-// Entry point for che-apple-mail-mcp
-let server = try await CheAppleMailMCPServer()
-try await server.run()
+// Entry point for che-apple-mail-mcp.
+// Parse the launch mode BEFORE starting the stdio server so the onboarding
+// flags (--setup / --check-fda, #213) divert cleanly and the default MCP stdio
+// path stays byte-for-byte untouched.
+switch RunMode.parse(CommandLine.arguments) {
+case .server:
+    let server = try await CheAppleMailMCPServer()
+    try await server.run()
+case .checkFDA:
+    SetupCLI.runCheckFDA()
+case .setup:
+    await SetupWindow.run()
+}

--- a/Sources/MailSQLite/FDAStatus.swift
+++ b/Sources/MailSQLite/FDAStatus.swift
@@ -15,14 +15,19 @@ public enum FDAStatus {
 
     /// Result of the read probe.
     public enum Probe: Equatable {
-        case granted      // the Envelope Index opened for reading — FDA is in effect
-        case denied       // the file exists but the open was refused (TCC) — FDA not granted
-        case noMailData   // no Envelope Index on disk (Apple Mail never set up) — can't tell
+        case granted       // the Envelope Index opened for reading — FDA is in effect
+        case denied        // EPERM/EACCES — the open was refused (TCC) — FDA not granted
+        case noMailData    // ENOENT — no Envelope Index on disk (Mail not set up) — can't tell
+        case undetermined  // any other errno (EMFILE, EIO, EISDIR, …) — an unexpected error, not a clear denial
     }
 
-    /// Probe FDA by attempting to open `path` for reading. `fopen` honors TCC, so
-    /// a refused open (`EPERM`/`EACCES`) means FDA is not granted, while `ENOENT`
-    /// means there is simply no Mail data to read.
+    /// Probe FDA by attempting to open `path` for reading. `fopen` honors TCC.
+    /// The `errno` after a failed open is discriminated precisely so we never
+    /// report a transient/unexpected failure as a TCC denial (which would
+    /// mislead the user into a pointless grant):
+    ///   - `EPERM` / `EACCES` → `.denied` (the genuine FDA-refusal signal)
+    ///   - `ENOENT`           → `.noMailData` (no file to read; Mail not set up)
+    ///   - anything else      → `.undetermined` (EMFILE under fd exhaustion, EIO, …)
     ///
     /// Default path is the real Envelope Index; tests pass a temp path.
     public static func probe(path: String = EnvelopeIndexReader.defaultDatabasePath) -> Probe {
@@ -32,10 +37,15 @@ public enum FDAStatus {
             fclose(fp)
             return .granted
         }
-        // Distinguish "no such file" from "refused".
-        return errno == ENOENT ? .noMailData : .denied
+        // Capture errno immediately — any later call could clobber it.
+        let err = errno
+        switch err {
+        case EPERM, EACCES: return .denied
+        case ENOENT:        return .noMailData
+        default:            return .undetermined
+        }
         #else
-        return .denied
+        return .undetermined
         #endif
     }
 
@@ -45,9 +55,11 @@ public enum FDAStatus {
         case .granted:
             return "Full Disk Access: GRANTED — the Apple Mail Envelope Index is readable."
         case .denied:
-            return "Full Disk Access: DENIED — the Envelope Index exists but this process can't read it."
+            return "Full Disk Access: DENIED — the Envelope Index exists but this process can't read it (permission refused)."
         case .noMailData:
             return "Full Disk Access: UNKNOWN — no Apple Mail Envelope Index on disk yet (Mail not set up)."
+        case .undetermined:
+            return "Full Disk Access: UNDETERMINED — the Envelope Index couldn't be opened due to an unexpected error."
         }
     }
 }

--- a/Sources/MailSQLite/FDAStatus.swift
+++ b/Sources/MailSQLite/FDAStatus.swift
@@ -1,0 +1,53 @@
+import Foundation
+#if canImport(Darwin)
+import Darwin
+#endif
+
+/// Functional probe of whether this process can actually read Apple Mail's
+/// Envelope Index — the reliable signal for **Full Disk Access** status. macOS
+/// exposes no query API for the FDA grant itself (#213), so the only honest
+/// signal is "can we read the file?". We deliberately do NOT try to *name* the
+/// responsible process to grant — there is no reliable in-process API for that
+/// (#214: `responsibility_get_pid_responsible_for_pid` returns self). The probe
+/// reports status only; the *guidance* (which app to grant) lives in
+/// `FullDiskAccessHelp` and names candidates, it never guesses.
+public enum FDAStatus {
+
+    /// Result of the read probe.
+    public enum Probe: Equatable {
+        case granted      // the Envelope Index opened for reading — FDA is in effect
+        case denied       // the file exists but the open was refused (TCC) — FDA not granted
+        case noMailData   // no Envelope Index on disk (Apple Mail never set up) — can't tell
+    }
+
+    /// Probe FDA by attempting to open `path` for reading. `fopen` honors TCC, so
+    /// a refused open (`EPERM`/`EACCES`) means FDA is not granted, while `ENOENT`
+    /// means there is simply no Mail data to read.
+    ///
+    /// Default path is the real Envelope Index; tests pass a temp path.
+    public static func probe(path: String = EnvelopeIndexReader.defaultDatabasePath) -> Probe {
+        #if canImport(Darwin)
+        errno = 0
+        if let fp = fopen(path, "rb") {
+            fclose(fp)
+            return .granted
+        }
+        // Distinguish "no such file" from "refused".
+        return errno == ENOENT ? .noMailData : .denied
+        #else
+        return .denied
+        #endif
+    }
+
+    /// One-line human summary for CLI / `check_fda` tool output.
+    public static func summary(_ probe: Probe) -> String {
+        switch probe {
+        case .granted:
+            return "Full Disk Access: GRANTED — the Apple Mail Envelope Index is readable."
+        case .denied:
+            return "Full Disk Access: DENIED — the Envelope Index exists but this process can't read it."
+        case .noMailData:
+            return "Full Disk Access: UNKNOWN — no Apple Mail Envelope Index on disk yet (Mail not set up)."
+        }
+    }
+}

--- a/Sources/MailSQLite/FDAStatus.swift
+++ b/Sources/MailSQLite/FDAStatus.swift
@@ -57,7 +57,10 @@ public enum FDAStatus {
         case .denied:
             return "Full Disk Access: DENIED — the Envelope Index exists but this process can't read it (permission refused)."
         case .noMailData:
-            return "Full Disk Access: UNKNOWN — no Apple Mail Envelope Index on disk yet (Mail not set up)."
+            // ENOENT is ambiguous: Mail may genuinely not be set up, OR Full Disk
+            // Access is denied — ~/Library/Mail is a TCC-protected 0700 directory,
+            // so a denial can surface as "no such file" (#213 verify, DA #8).
+            return "Full Disk Access: UNKNOWN — no Apple Mail Envelope Index found (Mail isn't set up, OR Full Disk Access is denied and hiding it)."
         case .undetermined:
             return "Full Disk Access: UNDETERMINED — the Envelope Index couldn't be opened due to an unexpected error."
         }

--- a/Tests/CheAppleMailMCPTests/RunModeTests.swift
+++ b/Tests/CheAppleMailMCPTests/RunModeTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import CheAppleMailMCP
+
+/// #213 — `--setup` / `--check-fda` must divert before the stdio server starts,
+/// and crucially the no-flag default must stay `.server` so the MCP path is
+/// untouched. These pin the dispatch contract.
+final class RunModeTests: XCTestCase {
+
+    func testNoFlagsDefaultsToServer() {
+        XCTAssertEqual(RunMode.parse(["/usr/bin/CheAppleMailMCP"]), .server)
+        XCTAssertEqual(RunMode.parse([]), .server)
+    }
+
+    func testSetupFlagSelectsSetup() {
+        XCTAssertEqual(RunMode.parse(["bin", "--setup"]), .setup)
+    }
+
+    func testCheckFdaFlagSelectsCheckFDA() {
+        XCTAssertEqual(RunMode.parse(["bin", "--check-fda"]), .checkFDA)
+    }
+
+    func testSetupWinsOverCheckFda() {
+        // If both are present the GUI (richer) wins — deterministic, not argv-order dependent.
+        XCTAssertEqual(RunMode.parse(["bin", "--check-fda", "--setup"]), .setup)
+        XCTAssertEqual(RunMode.parse(["bin", "--setup", "--check-fda"]), .setup)
+    }
+
+    func testUnknownFlagsAreIgnoredAndStayServer() {
+        // An unrecognized flag must NOT divert — the stdio MCP path is the default.
+        XCTAssertEqual(RunMode.parse(["bin", "--verbose", "--whatever"]), .server)
+    }
+}

--- a/Tests/MailSQLiteTests/FDAStatusTests.swift
+++ b/Tests/MailSQLiteTests/FDAStatusTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import MailSQLite
+
+/// #213 — the functional FDA probe is the only honest signal for Full Disk
+/// Access (no query API exists). These tests pin the readable / missing-file
+/// branches; the TCC-refused (`.denied`) branch can't be exercised without a
+/// real denied grant, but the `errno` discrimination is covered by the missing
+/// vs readable cases.
+final class FDAStatusTests: XCTestCase {
+
+    func testProbeReadableFileReportsGranted() throws {
+        // A file we can definitely open stands in for a readable Envelope Index.
+        let tmp = NSTemporaryDirectory() + "fda-probe-\(ProcessInfo.processInfo.globallyUniqueString).bin"
+        try Data([0x01, 0x02, 0x03]).write(to: URL(fileURLWithPath: tmp))
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+
+        XCTAssertEqual(FDAStatus.probe(path: tmp), .granted,
+                       "a readable file must probe as .granted")
+    }
+
+    func testProbeMissingFileReportsNoMailData() {
+        let missing = NSTemporaryDirectory() + "fda-probe-does-not-exist-\(ProcessInfo.processInfo.globallyUniqueString)"
+        XCTAssertEqual(FDAStatus.probe(path: missing), .noMailData,
+                       "a nonexistent path is ENOENT → .noMailData, not .denied")
+    }
+
+    func testSummaryDistinguishesAllThreeStates() {
+        XCTAssertTrue(FDAStatus.summary(.granted).contains("GRANTED"))
+        XCTAssertTrue(FDAStatus.summary(.denied).contains("DENIED"))
+        XCTAssertTrue(FDAStatus.summary(.noMailData).contains("UNKNOWN"))
+        // All three must be distinct so a reader can tell them apart.
+        let all = Set([FDAStatus.summary(.granted), FDAStatus.summary(.denied), FDAStatus.summary(.noMailData)])
+        XCTAssertEqual(all.count, 3)
+    }
+
+    func testDefaultProbePathIsTheEnvelopeIndex() {
+        // The default path must be the real Envelope Index (not crash / empty).
+        XCTAssertTrue(EnvelopeIndexReader.defaultDatabasePath.hasSuffix("MailData/Envelope Index"))
+        // Probing it must not trap regardless of FDA state (returns some Probe).
+        _ = FDAStatus.probe()
+    }
+}

--- a/Tests/MailSQLiteTests/FDAStatusTests.swift
+++ b/Tests/MailSQLiteTests/FDAStatusTests.swift
@@ -24,13 +24,31 @@ final class FDAStatusTests: XCTestCase {
                        "a nonexistent path is ENOENT → .noMailData, not .denied")
     }
 
-    func testSummaryDistinguishesAllThreeStates() {
+    func testProbeUnreadableFileReportsDenied() throws {
+        // A 000-perm file the owner can't read reproduces the EACCES/EPERM path
+        // that distinguishes a genuine TCC denial from other errors. root
+        // bypasses file perms, so skip there (CI/local run as the user).
+        try XCTSkipIf(geteuid() == 0, "running as root bypasses file permissions")
+        let tmp = NSTemporaryDirectory() + "fda-probe-noperm-\(ProcessInfo.processInfo.globallyUniqueString).bin"
+        try Data([0x01]).write(to: URL(fileURLWithPath: tmp))
+        XCTAssertEqual(chmod(tmp, 0), 0, "chmod 000 must succeed for the test to be meaningful")
+        defer { _ = chmod(tmp, 0o644); try? FileManager.default.removeItem(atPath: tmp) }
+
+        XCTAssertEqual(FDAStatus.probe(path: tmp), .denied,
+                       "an unreadable (000) file is EACCES → .denied, not .undetermined")
+    }
+
+    func testSummaryDistinguishesAllFourStates() {
         XCTAssertTrue(FDAStatus.summary(.granted).contains("GRANTED"))
         XCTAssertTrue(FDAStatus.summary(.denied).contains("DENIED"))
         XCTAssertTrue(FDAStatus.summary(.noMailData).contains("UNKNOWN"))
-        // All three must be distinct so a reader can tell them apart.
-        let all = Set([FDAStatus.summary(.granted), FDAStatus.summary(.denied), FDAStatus.summary(.noMailData)])
-        XCTAssertEqual(all.count, 3)
+        XCTAssertTrue(FDAStatus.summary(.undetermined).contains("UNDETERMINED"))
+        // All four must be distinct so a reader (and check_fda) can tell them apart.
+        let all = Set([
+            FDAStatus.summary(.granted), FDAStatus.summary(.denied),
+            FDAStatus.summary(.noMailData), FDAStatus.summary(.undetermined),
+        ])
+        XCTAssertEqual(all.count, 4)
     }
 
     func testDefaultProbePathIsTheEnvelopeIndex() {

--- a/Tests/MailSQLiteTests/FDAStatusTests.swift
+++ b/Tests/MailSQLiteTests/FDAStatusTests.swift
@@ -1,5 +1,8 @@
 import XCTest
 @testable import MailSQLite
+#if canImport(Darwin)
+import Darwin
+#endif
 
 /// #213 — the functional FDA probe is the only honest signal for Full Disk
 /// Access (no query API exists). These tests pin the readable / missing-file
@@ -8,6 +11,9 @@ import XCTest
 /// vs readable cases.
 final class FDAStatusTests: XCTestCase {
 
+    // These three pin Darwin errno semantics (granted/noMailData/denied); on a
+    // non-Darwin platform probe() returns .undetermined, so guard them (#213 verify).
+    #if canImport(Darwin)
     func testProbeReadableFileReportsGranted() throws {
         // A file we can definitely open stands in for a readable Envelope Index.
         let tmp = NSTemporaryDirectory() + "fda-probe-\(ProcessInfo.processInfo.globallyUniqueString).bin"
@@ -37,6 +43,7 @@ final class FDAStatusTests: XCTestCase {
         XCTAssertEqual(FDAStatus.probe(path: tmp), .denied,
                        "an unreadable (000) file is EACCES → .denied, not .undetermined")
     }
+    #endif
 
     func testSummaryDistinguishesAllFourStates() {
         XCTAssertTrue(FDAStatus.summary(.granted).contains("GRANTED"))


### PR DESCRIPTION
Refs #213

## Summary
Proactive Full Disk Access onboarding — the **彈出式視窗** the user asked for, plus the headless complements. Solves "the user doesn't know what to do" without pretending to remove Apple's single manual FDA toggle.

- **`--setup`** — launch-on-demand SwiftUI window: live FDA + Automation status, "Open Full Disk Access settings" / "Copy binary path" buttons, 1.5s re-check timer → flips to "Ready ✅" the instant FDA is granted.
- **`--check-fda`** — headless status print + opens the pane if denied (no AppKit).
- **`check_fda` MCP tool** — reports FDA status + #214 guidance to Claude on demand.

Architecture: same-binary `--setup` (no extra distribution; both Claude Code `~/bin` and Claude Desktop `.mcpb` channels), gated entirely behind the flag so the **stdio MCP path is byte-for-byte untouched**. Names *candidates* (terminal / Claude Desktop / binary); does NOT claim to auto-name the exact responsible app (the #214 wall — no reliable in-process API).

## Checklist
- [x] Diagnose (Spectra; scope = full GUI per user choice)
- [x] Implement (2 commits)
- [ ] Verify (run /idd-verify #213)
- [x] **Verify-gated**: post-verify PASS = ready to merge → after merge, run /idd-close

## Test plan
- `FDAStatus` probe (granted/denied/noMailData via `errno`) — 4 unit tests
- `RunMode.parse` dispatch (`--setup`/`--check-fda`/default-server, unknown flags stay server) — 5 unit tests
- Full suite **676 tests, 0 failures**
- `--check-fda` smoke-tested (prints GRANTED; opens pane when denied)
- default no-flag path confirmed to still wait on stdin (stdio untouched)
- ⚠️ **`--setup` GUI window needs a MANUAL smoke-test** — it opens an `NSWindow`, can't be CI-unit-tested (no display). Its underlying model (probe + dispatch) is fully unit-tested.

## Out of scope (tracking)
- Cross-repo wrapper one-time reminder (`psychquant-claude-plugins`) — issue direction 4.

---
Generated by /idd-all. **Do NOT add a GitHub close trailer** — IDD discipline requires manual /idd-close after merge.
